### PR TITLE
fix: allow unchecking Example Nanopub when demoMode is on

### DIFF
--- a/frontend/src/components/ui/sonner.tsx
+++ b/frontend/src/components/ui/sonner.tsx
@@ -17,6 +17,7 @@ const Toaster = ({ ...props }: ToasterProps) => {
     <Sonner
       theme={resolvedTheme as ToasterProps["theme"]}
       className="toaster group"
+      visibleToasts={3}
       icons={{
         success: <CircleCheckIcon className="size-5 stroke-green-500" />,
         info: <InfoIcon className="size-5 stroke-foreground" />,

--- a/frontend/src/pages/np/create/CreateNanopub.tsx
+++ b/frontend/src/pages/np/create/CreateNanopub.tsx
@@ -40,7 +40,6 @@ export default function CreateNanopub() {
         templateUri={templateUri}
         onTemplateUriChange={handleTemplateChange}
         embedded={false}
-        demoMode={true} // TODO: currently hard coded as demo for web app
         orcidLinkAction={async () =>
           await authClient.linkSocial({ provider: "orcid" })
         } // TODO: ideally this should open in a new window so it doesn't wipe out the form entries

--- a/frontend/src/pages/np/create/components/NanopubEditor.tsx
+++ b/frontend/src/pages/np/create/components/NanopubEditor.tsx
@@ -281,8 +281,8 @@ export default function NanopubEditor({
         data,
         {
           orcid: identity.orcid,
-          name: identity.name,
-          isExample: demoMode || data?.isExampleNanopub === true,
+          name: identity.name?.trim(),
+          isExample: data?.isExampleNanopub === true,
         },
         identity.privateKey || EXAMPLE_privateKey,
       );

--- a/frontend/src/pages/np/create/components/NanopubEditor.tsx
+++ b/frontend/src/pages/np/create/components/NanopubEditor.tsx
@@ -109,11 +109,6 @@ export interface NanopubEditorProps {
   embedded?: boolean;
 
   /**
-   * If true, forces ExampleNanopublication property for generated RDF.
-   */
-  demoMode?: boolean;
-
-  /**
    * If true, show a small widget with the currently loaded profile info.
    */
   showProfile?: boolean;
@@ -189,7 +184,6 @@ export default function NanopubEditor({
   orcidLinkAction,
   embedded = false,
   showProfile = true,
-  demoMode = false,
 }: NanopubEditorProps) {
   // Local state for the "custom URI" input (when not using predefined template)
   const [inputUri, setInputUri] = useState<string | null>(null);
@@ -236,32 +230,15 @@ export default function NanopubEditor({
     console.log("Data entered:", data);
 
     if (!identity) {
-      toast.warning("Authentication Required", {
-        description: "You need to be signed in to publish nanopublications.",
-      });
-      return;
-    }
-
-    if (!identity.orcid) {
-      toast.warning("ORCID Required", {
+      toast.warning("Sign in to publish", {
         description:
-          "Your account must be linked to your ORCID to publish nanopublications.",
-        action: orcidLinkAction
-          ? {
-              label: "Link ORCID",
-              onClick: orcidLinkAction,
-            }
-          : undefined,
+          "The nanopub draft was generated but you cannot publish until you sign in.",
       });
-      return;
-    }
-
-    if (!identity.privateKey && !demoMode) {
-      toast.error("No Private Key", {
+    } else if (!identity.orcid || !identity.privateKey) {
+      toast.warning("Resolve account issues to publish", {
         description:
-          "Enter a private key in your Science Live account or use Demo Mode to sign with an example key.",
+          "The nanopub draft was generated but your account will need to meet the requirements before publishing.",
       });
-      return;
     }
 
     // Generate/Sign
@@ -280,11 +257,11 @@ export default function NanopubEditor({
       const signed = await template.generateNanopublication(
         data,
         {
-          orcid: identity.orcid,
-          name: identity.name?.trim(),
+          orcid: identity?.orcid || "https://orcid.org/0000-0000-0000-0000",
+          name: identity?.name?.trim() || "DEMO USER",
           isExample: data?.isExampleNanopub === true,
         },
-        identity.privateKey || EXAMPLE_privateKey,
+        identity?.privateKey || EXAMPLE_privateKey,
       );
 
       setGeneratedRdf(signed.signedRdf);
@@ -313,6 +290,35 @@ export default function NanopubEditor({
 
   const publish = async () => {
     if (!generatedRdf) return;
+
+    if (!identity) {
+      toast.warning("Authentication Required", {
+        description: "You need to be signed in to publish nanopublications.",
+      });
+      return;
+    }
+
+    if (!identity.orcid) {
+      toast.warning("ORCID Required", {
+        description:
+          "Your account must be linked to your ORCID to publish nanopublications.",
+        action: orcidLinkAction
+          ? {
+              label: "Link ORCID",
+              onClick: orcidLinkAction,
+            }
+          : undefined,
+      });
+      return;
+    }
+
+    if (!identity.privateKey) {
+      toast.error("No Private Key", {
+        description:
+          "Enter a private key in your Science Live account or use Demo Mode to sign with an example key.",
+      });
+      return;
+    }
 
     try {
       // publishRdf currently does not surface URI (server-dependent), so:
@@ -503,7 +509,7 @@ export default function NanopubEditor({
                   submit={generateNanopub}
                   prefilledData={{
                     ...(prefilledData ?? {}),
-                    isExampleNanopub: demoMode,
+                    isExampleNanopub: !identity,
                   }}
                 />
               </>
@@ -513,7 +519,7 @@ export default function NanopubEditor({
                 submit={generateNanopub}
                 prefilledData={{
                   ...(prefilledData ?? {}),
-                  isExampleNanopub: demoMode,
+                  isExampleNanopub: !identity,
                 }}
               />
             )}

--- a/frontend/src/pages/np/create/components/NanopubEditor.tsx
+++ b/frontend/src/pages/np/create/components/NanopubEditor.tsx
@@ -293,14 +293,14 @@ export default function NanopubEditor({
     if (!generatedRdf) return;
 
     if (!identity) {
-      toast.warning("Authentication Required", {
+      toast.error("Authentication Required", {
         description: "You need to be signed in to publish nanopublications.",
       });
       return;
     }
 
     if (!identity.orcid) {
-      toast.warning("ORCID Required", {
+      toast.error("ORCID Required", {
         description:
           "Your account must be linked to your ORCID to publish nanopublications.",
         action: orcidLinkAction
@@ -316,7 +316,7 @@ export default function NanopubEditor({
     if (!identity.privateKey) {
       toast.error("No Private Key", {
         description:
-          "Enter a private key in your Science Live account or use Demo Mode to sign with an example key.",
+          "Enter a private key in your Science Live account in order to publish.",
       });
       return;
     }

--- a/frontend/src/pages/np/create/components/NanopubEditor.tsx
+++ b/frontend/src/pages/np/create/components/NanopubEditor.tsx
@@ -229,18 +229,6 @@ export default function NanopubEditor({
   const generateNanopub = async (data: any) => {
     console.log("Data entered:", data);
 
-    if (!identity) {
-      toast.warning("Sign in to publish", {
-        description:
-          "The nanopub draft was generated but you cannot publish until you sign in.",
-      });
-    } else if (!identity.orcid || !identity.privateKey) {
-      toast.warning("Resolve account issues to publish", {
-        description:
-          "The nanopub draft was generated but your account will need to meet the requirements before publishing.",
-      });
-    }
-
     // Generate/Sign
     let template;
     try {
@@ -272,6 +260,19 @@ export default function NanopubEditor({
       toast.success("Nanopublication generated", {
         description: "Signed TriG generated, review before publishing.",
       });
+
+      if (!identity) {
+        toast.warning("Sign in to publish", {
+          description:
+            "The nanopub draft was generated but you cannot publish until you sign in.",
+        });
+      } else if (!identity.orcid || !identity.privateKey) {
+        toast.warning("Resolve account issues to publish", {
+          description:
+            "The nanopub draft was generated but your account will need to meet the requirements before publishing.",
+        });
+      }
+
       (scrollPreviewRef?.current as any)?.scrollIntoView({
         behavior: "smooth",
         block: "start",


### PR DESCRIPTION
## UPDATE:
Instead, we simply remove demoMode entirely, and allow generating any nanopubs (example or not) for any users including who are not signed in or not linked to orcid (or are missing private key), however those users are just not allowed to publish.

## Summary

Two small fixes for the nanopub creation flow:

1. **demoMode no longer forces Example flag** — Previously `demoMode={true}` (hardcoded in `CreateNanopub.tsx`) forced `isExample=true` via an OR condition, making the "Create Example Nanopub" checkbox non-functional. Now `demoMode` only sets the checkbox **default** — unticking it produces a real (non-example) nanopublication.

2. **Trim identity name** — Some ORCID-derived display names have a leading space (e.g. `" Anne Fouilloux"`). Added `.trim()` so the foaf:name in generated nanopubs is clean.

## Changes

`frontend/src/pages/np/create/components/NanopubEditor.tsx`:
- Line 285: `isExample: demoMode || data?.isExampleNanopub` → `isExample: data?.isExampleNanopub`
- Line 284: `name: identity.name` → `name: identity.name?.trim()`

## Test plan
- [ ] Go to `/np/create/`, select any template
- [ ] Verify "Create Example Nanopub" checkbox is checked by default
- [ ] Uncheck it, generate a nanopub → verify the TriG does NOT contain `npx:ExampleNanopub`
- [ ] Check it again, generate → verify it DOES contain `npx:ExampleNanopub`
- [ ] Verify the `foaf:name` in generated TriG has no leading space

🤖 Generated with [Claude Code](https://claude.com/claude-code)