### PR TITLE
fix(zotero): allow installation on Zotero 9

### DIFF
--- a/zotero/RELEASE.md
+++ b/zotero/RELEASE.md
@@ -1,8 +1,15 @@
 # How to make a new release
 
-1. Change the e.g. `"version": "1.0.0"` in zotero/package.json to a new version number, commit and push.
+1. Change the e.g. `"version": "1.0.0"` in [zotero/package.json](package.json) to a new version number, commit and push.
 2. Tag the commit in github e.g. `git tag v1.0.0` then `git push origin v1.0.0`.
 3. Run the [Zotero Plugin Release workflow](https://github.com/ScienceLiveHub/science-live-platform/actions/workflows/zotero-release.yml) in github.
 4. The plugin should automatically build and update the release as well, which means zotero users with auto-updates turned on will also get the update.
 5. Check the auto-generated release notes in github, and make corrections where necessary, take a look at previous for ideas.
 6. Test in Zotero via the auto-update to make sure everything works as expected.
+
+# Supporting new versions of Zotero
+
+1. Make sure `zotero-plugin-scaffold` is the latest version in [zotero/package.json](package.json).
+2. Fix any breaking changes in the latest Zotero plugin API.
+3. In [zotero/addon/manifest.json](addon/manifest.json) update `strict_max_version` to latest.
+4. Test dev (update to latest Zotero in dev-container: `sudo apt update && sudo apt instal zotero`) and make a new release (see above).

--- a/zotero/addon/manifest.json
+++ b/zotero/addon/manifest.json
@@ -14,7 +14,7 @@
       "id": "__addonID__",
       "update_url": "__updateURL__",
       "strict_min_version": "6.999",
-      "strict_max_version": "8.*"
+      "strict_max_version": "9.*"
     }
   }
 }

--- a/zotero/package.json
+++ b/zotero/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zotero-sciencelive",
   "type": "module",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Science Live plugin for Zotero - Create nanopublications from Zotero items and link them to your bibliography",
   "config": {
     "addonName": "Science Live",


### PR DESCRIPTION
## Summary
- Bumps the Zotero plugin's `strict_max_version` from `8.*` to `9.*` in `zotero/addon/manifest.json` so the XPI installs on Zotero 9 (released April 2026).
- Bumps plugin version 1.0.3 → 1.0.4.
- Fix #83 

Without this, Zotero 9 rejects the XPI at install time with "Add-on Installation Failed — The add-on 'Science Live' could not be installed. It may be incompatible with this version of Zotero."

The plugin code itself does not use any of the APIs that broke between Zotero 7 → 8 → 9 (no `.jsm` imports, no `Zotero.Promise`/Bluebird, no `XPCOMUtils`/`Components.utils.import`, no `nsIScriptableUnicodeConverter`). The dialog bundle is already built as ESM. So bumping the manifest cap is the only change required.

## Out of scope
- The `nanopubSearch.ts` 504 from `query.petapico.org` is a pre-existing bug (the file already has a `FIXME` at line 1) caused by `CONTAINS(STR(?s/?p/?o), …)` patterns that force a full-repo scan. Will be fixed in a follow-up PR that aligns the plugin's search with the platform's search.

## Test plan
- [x] `npm run build` from `zotero/` succeeds (includes `tsc --noEmit`)
- [x] `npm run lint:check` passes
- [x] XPI installs on Zotero 9 macOS without the incompatibility dialog
- [x] Plugin starts: `sciencelive-mainWindow.ftl` and `sciencelive-preferences.ftl` resolve, hooks register, right-click + window + reader menus appear
- [ ] Verify on Zotero 7 LTS that the cap bump didn't break anything backward (still installs given `strict_min_version: 6.999`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)