### PR TITLE
Add CITATION.cff and codemeta.json for Zenodo archival

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,41 @@
+cff-version: 1.2.0
+title: "Science Live: Platform for FAIR Nanopublications"
+message: "If you use this software, please cite it as below."
+type: software
+authors:
+  - family-names: Fouilloux
+    given-names: Anne
+    orcid: "https://orcid.org/0000-0002-1784-2920"
+    affiliation: "LifeWatch ERIC"
+  - family-names: Prema
+    given-names: Vijay
+    affiliation: "Prophet Town"
+  - name: "VitenHub AS"
+abstract: >-
+  Science Live transforms research into FAIR (Findable, Accessible,
+  Interoperable, Reusable) nanopublications — cryptographically signed,
+  machine-readable RDF assertions discoverable, citable, and composable
+  across the global nanopub network. The platform supports every stage
+  of the research lifecycle, from systematic reviews (PCC, PICO, PRISMA)
+  to claim publication (FORRT Claim, Replication Study, Replication
+  Outcome, Citation with CiTO) and synthesis (Research Software,
+  Research Synthesis), with ORCID-based author identity and Knowledge
+  Pixels nanopub network integration.
+repository-code: "https://github.com/ScienceLiveHub/science-live-platform"
+url: "https://platform.sciencelive4all.org"
+license: MIT
+version: "1.0.6"
+date-released: "2026-05-06"
+keywords:
+  - nanopublication
+  - FAIR
+  - FAIR4RS
+  - FORRT
+  - open-science
+  - semantic-web
+  - RDF
+  - ORCID
+  - research-software
+  - reproducibility
+  - knowledge-pixels
+  - cloudflare-workers

--- a/codemeta.json
+++ b/codemeta.json
@@ -1,0 +1,80 @@
+{
+  "@context": "https://doi.org/10.5063/schema/codemeta-2.0",
+  "@type": "SoftwareSourceCode",
+  "name": "Science Live: Platform for FAIR Nanopublications",
+  "description": "Science Live transforms research into FAIR (Findable, Accessible, Interoperable, Reusable) nanopublications — cryptographically signed, machine-readable RDF assertions discoverable, citable, and composable across the global nanopub network. The platform supports every stage of the research lifecycle, from systematic reviews (PCC, PICO, PRISMA) to claim publication (FORRT Claim, Replication Study, Replication Outcome, Citation with CiTO) and synthesis (Research Software, Research Synthesis), with ORCID-based author identity and Knowledge Pixels nanopub network integration.",
+  "version": "1.0.6",
+  "dateCreated": "2025-12-01",
+  "dateModified": "2026-05-06",
+  "license": "https://spdx.org/licenses/MIT",
+  "codeRepository": "https://github.com/ScienceLiveHub/science-live-platform",
+  "url": "https://platform.sciencelive4all.org",
+  "programmingLanguage": [
+    {
+      "@type": "ComputerLanguage",
+      "name": "TypeScript"
+    },
+    {
+      "@type": "ComputerLanguage",
+      "name": "JavaScript"
+    }
+  ],
+  "operatingSystem": "Web (any modern browser)",
+  "applicationCategory": "Open Science / Research Infrastructure",
+  "developmentStatus": "active",
+  "author": [
+    {
+      "@type": "Person",
+      "givenName": "Anne",
+      "familyName": "Fouilloux",
+      "@id": "https://orcid.org/0000-0002-1784-2920",
+      "affiliation": {
+        "@type": "Organization",
+        "name": "LifeWatch ERIC"
+      }
+    },
+    {
+      "@type": "Person",
+      "givenName": "Vijay",
+      "familyName": "Prema",
+      "affiliation": {
+        "@type": "Organization",
+        "name": "Prophet Town"
+      }
+    },
+    {
+      "@type": "Organization",
+      "name": "VitenHub AS"
+    }
+  ],
+  "keywords": [
+    "nanopublication",
+    "FAIR",
+    "FAIR4RS",
+    "FORRT",
+    "open-science",
+    "semantic-web",
+    "RDF",
+    "ORCID",
+    "research-software",
+    "reproducibility",
+    "knowledge-pixels",
+    "cloudflare-workers"
+  ],
+  "softwareRequirements": [
+    "Node.js >=20",
+    "React 19",
+    "Vite 7",
+    "Tailwind CSS 4",
+    "Hono",
+    "Better-Auth",
+    "Drizzle ORM",
+    "PostgreSQL",
+    "TypeScript >=5.9"
+  ],
+  "isPartOf": {
+    "@type": "Organization",
+    "name": "Science Live",
+    "url": "https://platform.sciencelive4all.org"
+  }
+}


### PR DESCRIPTION
## Summary

Adds machine-readable citation metadata to the repo so the GitHub ↔ Zenodo integration captures rich author + license + keyword data on the next release.

- **CITATION.cff** (CFF v1.2.0) — for citation tools (Zotero, Zenodo, Google Scholar)
- **codemeta.json** (CodeMeta-2.0) — for software-discovery indexes (Software Heritage, OpenAIRE)

Authors listed (consistent across both files):

1. Anne Fouilloux — LifeWatch ERIC — ORCID `0000-0002-1784-2920`
2. Vijay Prema — Prophet Town
3. VitenHub AS — institutional author (CFF `type: entity` / CodeMeta `@type: Organization`)

Both files declare `version: "1.0.6"` to match the latest release tag.

## Why now

Zenodo ↔ GitHub integration was just enabled for `ScienceLiveHub/science-live-platform`. On the next release, Zenodo will read these files to populate the deposit's authors, abstract, license, and keywords. Without them, the deposit gets the GitHub commit-based defaults (just an automated description).

## DOI field — deferred

`CITATION.cff` does not yet have a `doi:` field, and `codemeta.json` does not yet have `identifier`/`@id`. These will be added in the release commit that mints the first Zenodo concept DOI (likely v1.0.7 or whichever next release happens, bundled with real fixes per the team's preference to avoid metadata-only releases).

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('CITATION.cff'))"` parses cleanly
- [x] `python3 -c "import json; json.load(open('codemeta.json'))"` parses cleanly
- [ ] Optional: validate via [https://citation-file-format.github.io/cff-validator/](https://citation-file-format.github.io/cff-validator/) and the [CodeMeta validator](https://codemeta.github.io/codemeta-generator/)
- [ ] After merge + next release: confirm the Zenodo deposit shows three authors with correct affiliations + ORCID

## References

- [CITATION.cff schema](https://citation-file-format.github.io/)
- [CodeMeta-2.0 schema](https://codemeta.github.io/)
- FAIR4RS principles F1.1, F2, F3, R1.1: rich citable metadata