### PR TITLE
Fix curated viewers: show hidden fields (ViewResearchSoftware + ViewDataset)

### DIFF
--- a/frontend/src/pages/np/view/ViewDataset.tsx
+++ b/frontend/src/pages/np/view/ViewDataset.tsx
@@ -28,7 +28,11 @@ const { namedNode } = DataFactory;
 
 // Namespaces
 const FDOF_NS = "https://w3id.org/fdof/ontology#";
-const DCAT_NS = "http://www.w3.org/ns/dcat#";
+// The Dataset template emits dcat:contactPoint with the HTTPS namespace (the vast
+// majority of published datasets); a handful of early ones used HTTP, so we match
+// either form below. (n3 term matching is exact — http != https.)
+const DCAT_NS = "https://www.w3.org/ns/dcat#";
+const DCAT_NS_HTTP = "http://www.w3.org/ns/dcat#";
 const DCT_NS = "http://purl.org/dc/terms/";
 
 const PREDICATES = {
@@ -41,6 +45,7 @@ const PREDICATES = {
   subject: namedNode(DCT_NS + "subject"),
   license: namedNode(DCT_NS + "license"),
   contactPoint: namedNode(DCAT_NS + "contactPoint"),
+  contactPointHttp: namedNode(DCAT_NS_HTTP + "contactPoint"),
   fdoType: namedNode(FDOF_NS + "FAIRDigitalObject"),
 };
 
@@ -169,13 +174,20 @@ function extractDataset(store: NanopubStore): DatasetData | null {
     .filter((q) => Util.isNamedNode(q.object))
     .map((q) => q.object.value);
 
-  // Get contact point
-  const contactQuad = store.matchOne(
-    datasetNode,
-    PREDICATES.contactPoint,
-    null,
-    assertionGraph,
-  );
+  // Get contact point (dcat:contactPoint — https canonical, http legacy fallback)
+  const contactQuad =
+    store.matchOne(
+      datasetNode,
+      PREDICATES.contactPoint,
+      null,
+      assertionGraph,
+    ) ??
+    store.matchOne(
+      datasetNode,
+      PREDICATES.contactPointHttp,
+      null,
+      assertionGraph,
+    );
   const contactPoint = contactQuad?.object.value;
 
   // Get license

--- a/frontend/src/pages/np/view/ViewResearchSoftware.tsx
+++ b/frontend/src/pages/np/view/ViewResearchSoftware.tsx
@@ -10,7 +10,14 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { useLabels } from "@/hooks/use-labels";
 import { NanopubStore } from "@/lib/nanopub-store";
 import { NS } from "@/lib/rdf";
-import { ExternalLink, FileText, FolderGit2, Link2 } from "lucide-react";
+import {
+  ExternalLink,
+  FileText,
+  FlaskConical,
+  FolderGit2,
+  Link2,
+  Scale,
+} from "lucide-react";
 import { DataFactory, Util } from "n3";
 import { useMemo } from "react";
 import {
@@ -25,12 +32,18 @@ import { TEMPLATE_VIEW_ICONS } from "./view-registry";
 
 const { namedNode } = DataFactory;
 
-// Namespaces
+// Namespaces. schema.org appears as both http and https in nanopubs (the
+// Research Software template uses https), so match either form.
 const DCMITYPE_SOFTWARE = "http://purl.org/dc/dcmitype/Software";
-const SCHEMA_MAINTAINER = "http://schema.org/maintainer";
+const SCHEMA_MAINTAINER = [
+  "https://schema.org/maintainer",
+  "http://schema.org/maintainer",
+];
+const SCHEMA_RESULT = ["https://schema.org/result", "http://schema.org/result"];
 const SKOS_RELATED = "http://www.w3.org/2004/02/skos/core#related";
 const DCT_IS_PART_OF = "http://purl.org/dc/terms/isPartOf";
 const DCT_TITLE = "http://purl.org/dc/terms/title";
+const DCT_LICENSE = "http://purl.org/dc/terms/license";
 const CITO_SUPPORTS = "http://purl.org/spar/cito/supports";
 
 // --- Research Software extraction -----------------------------------------
@@ -42,8 +55,12 @@ interface ResearchSoftwareData {
   softwareUri: string;
   /** Repository/maintainer URL (e.g., GitHub) */
   repository?: string;
+  /** Research project (schema:result) this software was produced for */
+  project?: string;
   /** Parent project/collection this software is part of */
   partOf?: string;
+  /** License of the software (dct:license) — distinct from the nanopub's own license */
+  license?: string;
   /** Supporting publication DOIs */
   supportingPublications: string[];
   /** Related resources */
@@ -81,23 +98,32 @@ function extractResearchSoftware(
     store.findInternalLabel(softwareUri) ||
     softwareUri;
 
-  // Get repository/maintainer
-  const maintainerQuad = store.matchOne(
-    softwareNode,
-    namedNode(SCHEMA_MAINTAINER),
-    null,
-    assertionGraph,
-  );
-  const repository = maintainerQuad?.object.value;
+  // First object of the software subject under any of the given predicates.
+  const firstObject = (predicates: string[]): string | undefined => {
+    for (const p of predicates) {
+      const q = store.matchOne(
+        softwareNode,
+        namedNode(p),
+        null,
+        assertionGraph,
+      );
+      if (q) return q.object.value;
+    }
+    return undefined;
+  };
+
+  // Get repository/maintainer (schema:maintainer, http or https)
+  const repository = firstObject(SCHEMA_MAINTAINER);
+
+  // Get the research project the software was produced for (schema:result)
+  const project = firstObject(SCHEMA_RESULT);
+
+  // Get the software license (dct:license) — the license OF the software,
+  // which is distinct from the nanopublication's own license (in pubinfo).
+  const license = firstObject([DCT_LICENSE]);
 
   // Get partOf (parent project/collection)
-  const partOfQuad = store.matchOne(
-    softwareNode,
-    namedNode(DCT_IS_PART_OF),
-    null,
-    assertionGraph,
-  );
-  const partOf = partOfQuad?.object.value;
+  const partOf = firstObject([DCT_IS_PART_OF]);
 
   // Get supporting publications (cito:supports)
   const supportsQuads = store.getQuads(
@@ -125,7 +151,9 @@ function extractResearchSoftware(
     title,
     softwareUri,
     repository,
+    project,
     partOf,
+    license,
     supportingPublications,
     relatedResources,
   };
@@ -193,6 +221,40 @@ export function ViewResearchSoftware({ store }: CustomViewerProps) {
               <ExternalUriLink
                 uri={data.repository}
                 label={formatUrlForDisplay(data.repository)}
+                className="text-sm"
+              />
+            </div>
+          </div>
+        )}
+
+        {/* Research Project (schema:result) */}
+        {data.project && (
+          <div>
+            <ItemTitle
+              title="Research Project"
+              icon={<FlaskConical className="h-4 w-4 inline-block mr-1" />}
+            />
+            <div className="flex items-center gap-2">
+              <ExternalUriLink
+                uri={data.project}
+                label={getLabel(data.project) || formatUrlForDisplay(data.project)}
+                className="text-sm"
+              />
+            </div>
+          </div>
+        )}
+
+        {/* License of the software (distinct from the nanopublication's license) */}
+        {data.license && (
+          <div>
+            <ItemTitle
+              title="License"
+              icon={<Scale className="h-4 w-4 inline-block mr-1" />}
+            />
+            <div className="flex items-center gap-2">
+              <ExternalUriLink
+                uri={data.license}
+                label={getLabel(data.license) || formatUrlForDisplay(data.license)}
                 className="text-sm"
               />
             </div>


### PR DESCRIPTION
Two curated nanopub viewers were matching the wrong predicate URIs, so fields that **are present in the published nanopub** were silently hidden. `store.matchOne`/`getQuads` do exact term matching, so an `http` vs `https` namespace (or a wrong predicate) is a silent miss.

## `ViewResearchSoftware`

Verified against a real published software nanopub — its assertion contained every field, but the viewer only showed the title and supporting publications. Three causes:

- **License** (`dct:license`) was never extracted or shown.
- **Repository** matched `http://schema.org/maintainer`, but nanopubs (and the template) use `https://schema.org/maintainer`.
- **Research Project** was read from `dct:isPartOf`, but the template emits it under `schema:result`.

Fix: match `schema.org` in either `http`/`https` form, extract `schema:result` as the Research Project, and show the software's `dct:license`. Note the software's license (in the assertion) is deliberately distinct from the **nanopublication's own record license** (in pubinfo, shown under Publication Info).

## `ViewDataset`

Same class of bug, found by auditing the other curated viewers:

- **Contact** matched `http://www.w3.org/ns/dcat#contactPoint`, but the Dataset template and the large majority of published datasets use `https://www.w3.org/ns/dcat#contactPoint`, so the Contact field was hidden on every dataset.

Fix: match the `https` namespace (canonical) with an `http` fallback so the few legacy datasets still show.

## Notes

- Scope is limited to these two viewers. An audit of all other curated viewers confirmed they match their templates correctly — including cases that *deliberately* use `http` for `schema.org`/`dcat` (e.g. `endDate`, `bbox`, `temporal*`), which were left untouched.
- No behaviour change for nanopubs that were already displaying correctly; this only un-hides fields that were being dropped.
- Verified locally: `tsc -b` typecheck, `vite build`, `vitest` (110/110), and eslint all pass.
- Independent of the FORRT chain-wizard PR (no shared files), so merge order doesn't matter.