### PR TITLE
Recognise PICO/PCC research questions as chain roots in /np/constellation

### DIFF
--- a/api/src/np/constellation.test.ts
+++ b/api/src/np/constellation.test.ts
@@ -588,6 +588,8 @@ describe("classifyStepKind", () => {
         "research-software",
       ],
       ["Science Live Research Synthesis", "research-synthesis"],
+      ["Defining a PICO-based research question", "question"],
+      ["Defining a PCC-based research question", "question"],
     ];
     for (const [label, expected] of cases) {
       expect(classifyStepKind(label)).toBe(expected);
@@ -605,6 +607,24 @@ describe("classifyStepKind", () => {
         "DECLARING A REPLICATION STUDY OUTCOME according to forrt",
       ),
     ).toBe("outcome");
+  });
+
+  it("classifies research-question roots despite label drift", () => {
+    // The live labels are "Defining a PICO/PCC-based research question"; we
+    // match on acronym + "research question" so a reworded template still
+    // lands on "question" instead of falling through to "other".
+    expect(classifyStepKind("Define a PICO research question")).toBe(
+      "question",
+    );
+    expect(classifyStepKind("PCC-BASED RESEARCH QUESTION")).toBe("question");
+  });
+
+  it("does not classify a Paper Quotation as a question", () => {
+    expect(
+      classifyStepKind(
+        "Annotating a paper quotation with personal interpretation",
+      ),
+    ).toBe("quote");
   });
 });
 
@@ -1682,5 +1702,229 @@ describe("buildConstellation — AIDA-statement bridge", () => {
     // Quote is reachable only THROUGH the bridged AIDA — proves the bridge
     // re-enables downstream TriG mining past the Claim terminus.
     expect(uris).toContain(QUOTE);
+  });
+});
+
+// =============================================================================
+// PICO / PCC research-question roots
+// =============================================================================
+
+describe("buildConstellation — question-rooted chain", () => {
+  // Regression: a FORRT chain whose ROOT is a PICO or PCC research question
+  // (not a Paper Quotation) used to classify as "other", so `chains[].steps`
+  // started at AIDA and the root was reachable only via `nodes[]`.
+  const QUESTION =
+    "https://w3id.org/sciencelive/np/RAquestionBBBBBBBBBBBBBBBBBBBBBBBBBBBB";
+  const AIDA =
+    "https://w3id.org/sciencelive/np/RAaidaBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB";
+  const CLAIM =
+    "https://w3id.org/sciencelive/np/RAclaimBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB";
+  const STUDY =
+    "https://w3id.org/sciencelive/np/RAstudyBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB";
+  const OUTCOME =
+    "https://w3id.org/sciencelive/np/RAoutcomeBBBBBBBBBBBBBBBBBBBBBBBBBBBBB";
+  const AIDA_URI =
+    "http://purl.org/aida/Coarse%20projection%20grids%20reorder%20per-species%20risk.";
+
+  const TPL_QUESTION =
+    "https://w3id.org/np/RA5e5XeXy_-aNK5giB7kBAEQslTLVydHeM4YYEzhmEE2w";
+  const TPL_AIDA = "https://w3id.org/np/RAtplAidaBBBBBBBBBBBBBBBBBBBBBBBBBBBB";
+  const TPL_CLAIM = "https://w3id.org/np/RAtplClaimBBBBBBBBBBBBBBBBBBBBBBBBBBB";
+  const TPL_STUDY = "https://w3id.org/np/RAtplStudyBBBBBBBBBBBBBBBBBBBBBBBBBBB";
+  const TPL_OUTCOME =
+    "https://w3id.org/np/RAtplOutcomeBBBBBBBBBBBBBBBBBBBBBBBBB";
+
+  function tplTrig(label: string): string {
+    return `
+sub:assertion {
+  sub:assertion a nt:AssertionTemplate;
+    rdfs:label "${label}" .
+}
+`;
+  }
+
+  function bodyQuestion(): string {
+    return `
+@prefix this: <${QUESTION}> .
+sub:assertion {
+  <${QUESTION}#question> a <http://data.cochrane.org/ontologies/pico/PICO>,
+      <https://w3id.org/sciencelive/o/terms/DescriptiveResearchQuestion>;
+    <http://www.w3.org/2000/01/rdf-schema#label> "Grid resolution and projected risk";
+    <http://purl.org/dc/terms/description> "In Iberian Bombus species, does a coarse projection grid reorder per-species extirpation risk compared with a fine grid?";
+    <http://data.cochrane.org/ontologies/pico/population> <${QUESTION}#population>;
+    <http://data.cochrane.org/ontologies/pico/interventionGroup> <${QUESTION}#intervention>;
+    <http://data.cochrane.org/ontologies/pico/comparatorGroup> <${QUESTION}#comparator>;
+    <http://data.cochrane.org/ontologies/pico/outcomeGroup> <${QUESTION}#outcome> .
+
+  <${QUESTION}#population> <http://purl.org/dc/terms/description> "Iberian Bombus species" .
+  <${QUESTION}#intervention> <http://purl.org/dc/terms/description> "Coarse 50 km grid" .
+  <${QUESTION}#comparator> <http://purl.org/dc/terms/description> "Fine 10 km grid" .
+  <${QUESTION}#outcome> <http://purl.org/dc/terms/description> "Per-species risk ranking" .
+}
+sub:pubinfo {
+  this: <https://w3id.org/np/o/ntemplate/wasCreatedFromTemplate> <${TPL_QUESTION}> .
+}
+`;
+  }
+
+  function bodyAida(): string {
+    return `
+@prefix this: <${AIDA}> .
+sub:assertion {
+  <${AIDA_URI}> a <http://purl.org/petapico/o/hycl#AIDA-Sentence> .
+  <${QUESTION}> a <foo> .
+}
+sub:pubinfo {
+  this: <https://w3id.org/np/o/ntemplate/wasCreatedFromTemplate> <${TPL_AIDA}> .
+}
+`;
+  }
+
+  function bodyClaim(): string {
+    return `
+@prefix this: <${CLAIM}> .
+sub:assertion {
+  <${CLAIM}> a <https://w3id.org/sciencelive/o/terms/model_performance-FORRT-Claim>;
+    <https://w3id.org/sciencelive/o/terms/asAidaStatement> <${AIDA_URI}> .
+  <${AIDA}> a <foo> .
+}
+sub:pubinfo {
+  this: <https://w3id.org/np/o/ntemplate/wasCreatedFromTemplate> <${TPL_CLAIM}> .
+}
+`;
+  }
+
+  function bodyStudy(): string {
+    return `
+@prefix this: <${STUDY}> .
+sub:assertion {
+  <${STUDY}> a <https://w3id.org/sciencelive/o/terms/FORRT-Replication-Study>;
+    <https://w3id.org/sciencelive/o/terms/hasScopeDescription> "Iberian Bombus, two grid resolutions";
+    <https://w3id.org/sciencelive/o/terms/hasMethodologyDescription> "GLMM projection at 10 km and 50 km";
+    <https://w3id.org/sciencelive/o/terms/targetsClaim> <${CLAIM}> .
+}
+sub:pubinfo {
+  this: <https://w3id.org/np/o/ntemplate/wasCreatedFromTemplate> <${TPL_STUDY}> .
+}
+`;
+  }
+
+  function bodyOutcome(): string {
+    return `
+@prefix this: <${OUTCOME}> .
+sub:assertion {
+  <${OUTCOME}> a <https://w3id.org/sciencelive/o/terms/FORRT-Replication-Outcome>;
+    <http://www.w3.org/2000/01/rdf-schema#label> "Grid resolution reorders low-N species";
+    <https://w3id.org/sciencelive/o/terms/hasValidationStatus> <https://w3id.org/sciencelive/o/terms/PartiallySupported>;
+    <https://w3id.org/sciencelive/o/terms/hasConfidenceLevel> <https://w3id.org/sciencelive/o/terms/HighConfidence>;
+    <https://w3id.org/sciencelive/o/terms/isOutcomeOf> <${STUDY}> .
+}
+sub:pubinfo {
+  this: <https://w3id.org/np/o/ntemplate/wasCreatedFromTemplate> <${TPL_OUTCOME}> .
+}
+`;
+  }
+
+  function makeKp(questionTemplateLabel: string) {
+    const trigMap: Record<string, string> = {
+      [`https://w3id.org/np/${OUTCOME.split("/").pop()}`]: bodyOutcome(),
+      [`https://w3id.org/np/${STUDY.split("/").pop()}`]: bodyStudy(),
+      [`https://w3id.org/np/${CLAIM.split("/").pop()}`]: bodyClaim(),
+      [`https://w3id.org/np/${AIDA.split("/").pop()}`]: bodyAida(),
+      [`https://w3id.org/np/${QUESTION.split("/").pop()}`]: bodyQuestion(),
+      [TPL_OUTCOME]: tplTrig(
+        "Declaring a replication study outcome according to FORRT",
+      ),
+      [TPL_STUDY]: tplTrig(
+        "Declaring a replication study design according to FORRT",
+      ),
+      [TPL_CLAIM]: tplTrig("Declaring an original claim according to FORRT"),
+      [TPL_AIDA]: tplTrig(
+        "Expressing a statement about research as an AIDA sentence",
+      ),
+      [TPL_QUESTION]: tplTrig(questionTemplateLabel),
+    };
+    return vi.fn(async (url: string | URL | Request) => {
+      const u = typeof url === "string" ? url : url.toString();
+      if (u === NANOPUB_SPARQL_ENDPOINT_FULL)
+        return new Response(sparqlBindings([]), {
+          status: 200,
+          headers: { "content-type": "application/sparql-results+json" },
+        });
+      const body = trigMap[u];
+      if (body)
+        return new Response(body, {
+          status: 200,
+          headers: { "content-type": "application/trig" },
+        });
+      return new Response("nf", { status: 404 });
+    });
+  }
+
+  const OPTS = { depthLimit: 6, maxNodes: 80, concurrency: 2 };
+
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("puts the PICO Question FIRST in chains[].steps", async () => {
+    vi.stubGlobal("fetch", makeKp("Defining a PICO-based research question"));
+    const c = await buildConstellation(OUTCOME, OPTS);
+    expect(c.chains).toHaveLength(1);
+    expect(c.chains[0].steps.map((s) => s.step)).toEqual([
+      "Question",
+      "AIDA",
+      "Claim",
+      "Study",
+      "Outcome",
+    ]);
+  });
+
+  it("classifies the PICO root node as a question, not 'other'", async () => {
+    vi.stubGlobal("fetch", makeKp("Defining a PICO-based research question"));
+    const c = await buildConstellation(OUTCOME, OPTS);
+    const node = c.nodes.find((n) => n.uri === QUESTION);
+    expect(node?.stepKind).toBe("question");
+    expect(node?.question?.framework).toBe("PICO");
+  });
+
+  it("carries the label, full question text and components on the step", async () => {
+    vi.stubGlobal("fetch", makeKp("Defining a PICO-based research question"));
+    const c = await buildConstellation(OUTCOME, OPTS);
+    const step = c.chains[0].steps[0];
+    expect(step.uri).toBe(QUESTION);
+    expect(step.framework).toBe("PICO");
+    expect(step.label).toBe("Grid resolution and projected risk");
+    expect(step.text).toMatch(/does a coarse projection grid reorder/);
+    expect(step.components?.map((x) => x.label)).toEqual([
+      "Population",
+      "Intervention",
+      "Comparator",
+      "Outcome",
+    ]);
+    expect(step.components?.map((x) => x.text)).toEqual([
+      "Iberian Bombus species",
+      "Coarse 50 km grid",
+      "Fine 10 km grid",
+      "Per-species risk ranking",
+    ]);
+  });
+
+  it("also works for a PCC-rooted chain", async () => {
+    vi.stubGlobal("fetch", makeKp("Defining a PCC-based research question"));
+    const c = await buildConstellation(OUTCOME, OPTS);
+    // The fixture assertion is PICO-shaped; only the template label changes,
+    // so this pins the classifier branch rather than the extractor.
+    expect(c.chains[0].steps[0].step).toBe("Question");
+    expect(c.nodes.find((n) => n.uri === QUESTION)?.stepKind).toBe("question");
+  });
+
+  it("emits no Question step when the template label is unrecognised", async () => {
+    vi.stubGlobal("fetch", makeKp("Some unrelated template"));
+    const c = await buildConstellation(OUTCOME, OPTS);
+    expect(c.chains[0].steps.map((s) => s.step)).toEqual([
+      "AIDA",
+      "Claim",
+      "Study",
+      "Outcome",
+    ]);
   });
 });

--- a/api/src/np/constellation.ts
+++ b/api/src/np/constellation.ts
@@ -18,6 +18,7 @@ import {
   extractNanopubUris,
   extractOrcids,
   extractOutcomeFields,
+  extractQuestionFields,
   extractQuoteFields,
   extractResearchSoftwareFields,
   extractResearchSynthesisFields,
@@ -28,6 +29,7 @@ import {
   type CitoFields,
   type ClaimFields,
   type OutcomeFields,
+  type QuestionFields,
   type QuoteFields,
   type ResearchSoftwareFields,
   type ResearchSynthesisFields,
@@ -41,6 +43,7 @@ import {
  */
 export type StepKind =
   | "quote"
+  | "question"
   | "aida"
   | "claim"
   | "study"
@@ -65,6 +68,7 @@ export type ConstellationNode = {
   study?: StudyFields;
   claim?: ClaimFields;
   quote?: QuoteFields;
+  question?: QuestionFields;
   aida?: AidaFields;
   cito?: CitoFields;
   researchSoftware?: ResearchSoftwareFields;
@@ -82,6 +86,7 @@ export type ConstellationEdge = {
 export type ChainStep = {
   step:
     | "Quote"
+    | "Question"
     | "AIDA"
     | "Claim"
     | "Study"
@@ -104,6 +109,10 @@ export type ChainStep = {
   zenodoDoi?: string;
   relations?: string[];
   targets?: string[];
+  /** Question steps only — "PICO" or "PCC". */
+  framework?: string;
+  /** Question steps only — the PICO/PCC components in acronym order. */
+  components?: QuestionFields["components"];
 };
 
 export type Chain = {
@@ -303,6 +312,9 @@ async function processNode(
     case "quote":
       node.quote = extractQuoteFields(trig);
       break;
+    case "question":
+      node.question = extractQuestionFields(trig);
+      break;
     case "aida":
       node.aida = extractAidaFields(trig);
       break;
@@ -444,6 +456,12 @@ export function classifyStepKind(stepType: string): StepKind {
   if (s.includes("replication study design")) return "study";
   if (s.includes("original claim")) return "claim";
   if (s.includes("paper quotation")) return "quote";
+  // A FORRT chain can be rooted in a structured research question instead of
+  // a Paper Quotation. Match on the acronym + "research question" so minor
+  // label drift ("Defining a PICO-based research question" vs a future
+  // "Define a PICO research question") still classifies.
+  if (s.includes("pico") && s.includes("research question")) return "question";
+  if (s.includes("pcc") && s.includes("research question")) return "question";
   if (s.includes("aida sentence")) return "aida";
   if (s.includes("citations with cito") || s.includes("cito citation"))
     return "cito";
@@ -510,6 +528,7 @@ function assembleChains(
   const claims = byKind.get("claim") ?? [];
   const studies = byKind.get("study") ?? [];
   const quotes = byKind.get("quote") ?? [];
+  const questions = byKind.get("question") ?? [];
   const aidas = byKind.get("aida") ?? [];
   const citos = byKind.get("cito") ?? [];
   const researchSoftwares = byKind.get("research-software") ?? [];
@@ -536,6 +555,12 @@ function assembleChains(
     // Quote — find the Quote node that the AIDA or Claim references.
     const quote =
       findQuoteForAida(aida, quotes) ?? findRelated(outcome, quotes);
+
+    // Research-question root — the alternative to a Quote root. Same weak
+    // linkage as Quote: FORRT has no AIDA->root predicate, so this only
+    // resolves when the constellation holds exactly one question node.
+    const question =
+      findQuestionForAida(aida, questions) ?? findRelated(outcome, questions);
 
     // CiTO node whose citing entity (subject) is THIS outcome. This is the
     // outcome-level CiTO citation that connects the Outcome to the upstream
@@ -564,6 +589,17 @@ function assembleChains(
         uri: quote.uri,
         text: quote.quote.quotedText,
         targets: quote.quote.citedDoi ? [quote.quote.citedDoi] : [],
+      });
+    // A chain is rooted in EITHER a Quote or a Question. If a constellation
+    // somehow yields both, emit both (Quote first) rather than dropping one.
+    if (question && question.question)
+      steps.push({
+        step: "Question",
+        uri: question.uri,
+        label: question.question.label,
+        text: question.question.question,
+        framework: question.question.framework,
+        components: question.question.components,
       });
     if (aida && aida.aida)
       steps.push({ step: "AIDA", uri: aida.uri, text: aida.aida.sentence });
@@ -696,6 +732,25 @@ function findQuoteForAida(
   // Quote in the constellation" when there's exactly one.
   if (quotes.length === 1) return quotes[0];
   return undefined;
+}
+
+/**
+ * Mirror of `findQuoteForAida` for question-rooted chains. FORRT has no
+ * explicit AIDA -> research-question predicate either, so the only linkage
+ * available is "there is exactly one question node in the constellation".
+ *
+ * KNOWN LIMITATION: in a multi-chain constellation where several chains each
+ * have their own PICO/PCC root, this returns undefined for every chain and no
+ * Question step is emitted. Attaching the wrong question to a chain would be
+ * worse than omitting it, so we stay conservative until the vocabulary gains
+ * a real root predicate.
+ */
+function findQuestionForAida(
+  aida: ConstellationNode | undefined,
+  questions: ConstellationNode[],
+): ConstellationNode | undefined {
+  void aida;
+  return questions.length === 1 ? questions[0] : undefined;
 }
 
 /**

--- a/api/src/np/trig.test.ts
+++ b/api/src/np/trig.test.ts
@@ -26,6 +26,7 @@ import {
   extractPredicateValueAny,
   extractPredicateValues,
   extractPredicateValuesAny,
+  extractQuestionFields,
   extractQuoteFields,
   extractResearchSoftwareFields,
   extractResearchSynthesisFields,
@@ -1173,5 +1174,207 @@ describe("canonicalNanopubUri security boundary", () => {
     expect(
       canonicalNanopubUri('https://w3id.org/np/RA"; SELECT * } #'),
     ).toBeNull();
+  });
+});
+
+// =============================================================================
+// PICO / PCC research-question roots
+// =============================================================================
+
+describe("extractQuestionFields — PICO", () => {
+  const ROOT =
+    "https://w3id.org/sciencelive/np/RApicoAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+  const PICO_TRIG = `
+sub:assertion {
+  <${ROOT}> a <http://data.cochrane.org/ontologies/pico/PICO>,
+      <https://w3id.org/sciencelive/o/terms/DescriptiveResearchQuestion>;
+    <http://www.w3.org/2000/01/rdf-schema#label> "Grid resolution and Bombus extirpation risk";
+    <http://purl.org/dc/terms/description> """In Iberian Bombus species, does a coarse projection grid change projected extirpation risk compared with a fine grid?""";
+    <http://data.cochrane.org/ontologies/pico/population> <${ROOT}/population>;
+    <http://data.cochrane.org/ontologies/pico/interventionGroup> <${ROOT}/intervention>;
+    <http://data.cochrane.org/ontologies/pico/comparatorGroup> <${ROOT}/comparator>;
+    <http://data.cochrane.org/ontologies/pico/outcomeGroup> <${ROOT}/outcome> .
+
+  <${ROOT}/population> <http://purl.org/dc/terms/description> "Iberian Bombus species with at least 10 occupied cells" .
+  <${ROOT}/intervention> <http://purl.org/dc/terms/description> "Coarse 50 km projection grid" .
+  <${ROOT}/comparator> <http://purl.org/dc/terms/description> "Fine 10 km projection grid" .
+  <${ROOT}/outcome> <http://purl.org/dc/terms/description> "Projected per-species extirpation risk ranking" .
+}
+`;
+
+  it("detects the PICO framework", () => {
+    expect(extractQuestionFields(PICO_TRIG).framework).toBe("PICO");
+  });
+
+  it("keeps rdfs:label and dct:description distinct", () => {
+    const q = extractQuestionFields(PICO_TRIG);
+    expect(q.label).toBe("Grid resolution and Bombus extirpation risk");
+    expect(q.question).toMatch(/does a coarse projection grid change/);
+    expect(q.question).not.toBe(q.label);
+  });
+
+  it("resolves all four components through the component nodes", () => {
+    const q = extractQuestionFields(PICO_TRIG);
+    expect(q.components.map((c) => c.key)).toEqual([
+      "population",
+      "intervention",
+      "comparator",
+      "outcome",
+    ]);
+    expect(q.components.map((c) => c.label)).toEqual([
+      "Population",
+      "Intervention",
+      "Comparator",
+      "Outcome",
+    ]);
+    expect(q.components.map((c) => c.text)).toEqual([
+      "Iberian Bombus species with at least 10 occupied cells",
+      "Coarse 50 km projection grid",
+      "Fine 10 km projection grid",
+      "Projected per-species extirpation risk ranking",
+    ]);
+  });
+
+  it("never leaks a component URI into the component text", () => {
+    for (const c of extractQuestionFields(PICO_TRIG).components) {
+      expect(c.text).not.toMatch(/^https?:\/\//);
+    }
+  });
+});
+
+describe("extractQuestionFields — PCC", () => {
+  const ROOT =
+    "https://w3id.org/sciencelive/np/RApccAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+  const PCC_TRIG = `
+sub:assertion {
+  <${ROOT}> a <https://w3id.org/sciencelive/o/terms/PccReviewQuestion>;
+    <http://www.w3.org/2000/01/rdf-schema#label> "Scoping HEALPix use in Earth observation";
+    <http://purl.org/dc/terms/description> "What is the extent of HEALPix grid adoption in published Earth-observation workflows?";
+    <https://w3id.org/sciencelive/o/terms/hasPccPopulation> <${ROOT}/population>;
+    <https://w3id.org/sciencelive/o/terms/hasPccConcept> <${ROOT}/concept>;
+    <https://w3id.org/sciencelive/o/terms/hasPccContext> <${ROOT}/context> .
+
+  <${ROOT}/population> <http://purl.org/dc/terms/description> "Peer-reviewed Earth-observation studies" .
+  <${ROOT}/concept> <http://purl.org/dc/terms/description> "Adoption of HEALPix hierarchical grids" .
+  <${ROOT}/context> <http://purl.org/dc/terms/description> "Operational satellite data pipelines, 2015-2026" .
+}
+`;
+
+  it("detects the PCC framework and its three components in order", () => {
+    const q = extractQuestionFields(PCC_TRIG);
+    expect(q.framework).toBe("PCC");
+    expect(q.components.map((c) => c.label)).toEqual([
+      "Population",
+      "Concept",
+      "Context",
+    ]);
+    expect(q.components.map((c) => c.text)).toEqual([
+      "Peer-reviewed Earth-observation studies",
+      "Adoption of HEALPix hierarchical grids",
+      "Operational satellite data pipelines, 2015-2026",
+    ]);
+  });
+
+  it("carries the label and the full question separately", () => {
+    const q = extractQuestionFields(PCC_TRIG);
+    expect(q.label).toBe("Scoping HEALPix use in Earth observation");
+    expect(q.question).toBe(
+      "What is the extent of HEALPix grid adoption in published Earth-observation workflows?",
+    );
+  });
+});
+
+describe("extractQuestionFields — subject-blind dereference trap", () => {
+  // Each component URI appears TWICE: once as the OBJECT of the root's
+  // component predicate, and once as the SUBJECT of its own description.
+  // Here the root's own dct:description sits AFTER the component predicate,
+  // so a naive "first dct:description following this URI" scan starts at the
+  // object occurrence and walks straight into the ROOT's description.
+  const ROOT =
+    "https://w3id.org/sciencelive/np/RAtrapAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+  const TRAP_TRIG = `
+sub:assertion {
+  <${ROOT}> a <http://data.cochrane.org/ontologies/pico/PICO>;
+    <http://data.cochrane.org/ontologies/pico/population> <${ROOT}/population>;
+    <http://www.w3.org/2000/01/rdf-schema#label> "Trap headline";
+    <http://purl.org/dc/terms/description> "ROOT QUESTION TEXT that a subject-blind scan would wrongly return." .
+
+  <${ROOT}/population> <http://purl.org/dc/terms/description> "COMPONENT TEXT" .
+}
+`;
+
+  it("reads the component's own description, not the root's", () => {
+    const q = extractQuestionFields(TRAP_TRIG);
+    expect(q.components).toHaveLength(1);
+    expect(q.components[0].text).toBe("COMPONENT TEXT");
+    // The exact value the naive implementation returns.
+    expect(q.components[0].text).not.toMatch(/ROOT QUESTION TEXT/);
+  });
+
+  it("still reads the root's own description as the question", () => {
+    const q = extractQuestionFields(TRAP_TRIG);
+    expect(q.question).toBe(
+      "ROOT QUESTION TEXT that a subject-blind scan would wrongly return.",
+    );
+    expect(q.label).toBe("Trap headline");
+  });
+});
+
+describe("extractQuestionFields — non-questions and partials", () => {
+  it("returns an empty framework for a TriG that is not a research question", () => {
+    const trig = `<x> <http://purl.org/spar/cito/hasQuotedText> "Some quoted text here." .`;
+    expect(extractQuestionFields(trig)).toEqual({
+      framework: "",
+      label: "",
+      question: "",
+      components: [],
+    });
+  });
+
+  it("omits components whose predicate is absent", () => {
+    const ROOT =
+      "https://w3id.org/sciencelive/np/RApartialAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+    const trig = `
+sub:assertion {
+  <${ROOT}> a <http://data.cochrane.org/ontologies/pico/PICO>;
+    <http://data.cochrane.org/ontologies/pico/population> <${ROOT}/population>;
+    <http://data.cochrane.org/ontologies/pico/outcomeGroup> <${ROOT}/outcome> .
+
+  <${ROOT}/population> <http://purl.org/dc/terms/description> "P text" .
+  <${ROOT}/outcome> <http://purl.org/dc/terms/description> "O text" .
+}
+`;
+    expect(extractQuestionFields(trig).components.map((c) => c.key)).toEqual([
+      "population",
+      "outcome",
+    ]);
+  });
+
+  it("returns an empty component text when the component node has no description", () => {
+    const ROOT =
+      "https://w3id.org/sciencelive/np/RAdanglingAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+    const trig = `
+sub:assertion {
+  <${ROOT}> a <http://data.cochrane.org/ontologies/pico/PICO>;
+    <http://data.cochrane.org/ontologies/pico/population> <${ROOT}/population> .
+}
+`;
+    expect(extractQuestionFields(trig).components).toEqual([
+      { key: "population", label: "Population", text: "" },
+    ]);
+  });
+
+  it("accepts an inlined literal component value", () => {
+    const ROOT =
+      "https://w3id.org/sciencelive/np/RAinlineAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+    const trig = `
+sub:assertion {
+  <${ROOT}> a <http://data.cochrane.org/ontologies/pico/PICO>;
+    <http://data.cochrane.org/ontologies/pico/population> "Inlined population text" .
+}
+`;
+    expect(extractQuestionFields(trig).components[0].text).toBe(
+      "Inlined population text",
+    );
   });
 });

--- a/api/src/np/trig.test.ts
+++ b/api/src/np/trig.test.ts
@@ -1378,3 +1378,130 @@ sub:assertion {
     );
   });
 });
+
+
+// ---------------------------------------------------------------------------
+// Real published nanopubs.
+//
+// Copied VERBATIM from what the resolver serves for
+//   https://w3id.org/np/RABINnMx1JSQG_DJlcsbCwExgkh8rtU7aBvVIHIRaCaB4  (PICO)
+//   https://w3id.org/np/RAEDNajh8Hz_fZbBRgOACKDxWrQYFfDYRks8-xxMEfKt4  (PCC)
+// trimmed to the @prefix header and the assertion graph.
+//
+// DO NOT TIDY THESE. Two details that look like noise are the whole point:
+//   - the root subject is a PREFIXED name (`sub:<slug>`), not an absolute <URI>
+//   - descriptions are `dc:description`, with `dc:` bound to purl.org/dc/terms
+// An earlier implementation passed every hand-written test in this file and
+// extracted NOTHING from real data because it assumed the other spelling.
+// Normalising `dc:` to `dct:` or expanding `sub:` here would silently retire
+// the only test that catches that class of bug.
+// ---------------------------------------------------------------------------
+
+const REAL_PICO_TRIG = `
+@prefix this: <https://w3id.org/sciencelive/np/RABINnMx1JSQG_DJlcsbCwExgkh8rtU7aBvVIHIRaCaB4> .
+@prefix sub: <https://w3id.org/sciencelive/np/RABINnMx1JSQG_DJlcsbCwExgkh8rtU7aBvVIHIRaCaB4/> .
+@prefix np: <http://www.nanopub.org/nschema#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix npx: <http://purl.org/nanopub/x/> .
+@prefix dc: <http://purl.org/dc/terms/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+sub:assertion {
+  <https://w3id.org/np/RA5e5XeXy_-aNK5giB7kBAEQslTLVydHeM4YYEzhmEE2w/comparatorGroup>
+    dc:description "The same detection + overlap-tracking algorithm run locally outside Galaxy (scikit-image + scipy), used to confirm the Galaxy result and to provide a hermetic, credential-free reproduction." .
+  
+  <https://w3id.org/np/RA5e5XeXy_-aNK5giB7kBAEQslTLVydHeM4YYEzhmEE2w/interventionGroup>
+    dc:description "The CellProfiler object-tracking pipeline (IdentifyPrimaryObjects + MeasureObjectSizeShape + TrackObjects) segments and tracks dividing cell nuclei in fluorescence time-lapse microscopy, applied to the IVT fields through a Galaxy workflow. It is a cross-discipline transfer of a bioimaging tracker to Earth-system science. Atmospheric rivers are identified using the established Guan & Waliser (2015) criteria (IVT threshold, length, length/width ratio, poleward flux)." .
+  
+  <https://w3id.org/np/RA5e5XeXy_-aNK5giB7kBAEQslTLVydHeM4YYEzhmEE2w/outcomeGroup> dc:description
+      "Recovery of coherent atmospheric-river objects per timestep — each with a persistent identity, centroid trajectory, length, IVT intensity and poleward flux — and whether the tracker follows them across time as they intensify, drift, merge and split." .
+  
+  <https://w3id.org/np/RA5e5XeXy_-aNK5giB7kBAEQslTLVydHeM4YYEzhmEE2w/population> dc:description
+      "Gridded fields of integrated water-vapour transport (IVT) from the ERA5 reanalysis (here the North Pacific, early February 2017, 6-hourly, 0.25 degrees), in which atmospheric rivers appear as long narrow filaments of high IVT." .
+  
+  sub:cellprofiler-trackobjects-atmospheric-rivers a <http://data.cochrane.org/ontologies/pico/PICO>,
+      <https://w3id.org/sciencelive/o/terms/DescriptiveResearchQuestion>;
+    <http://data.cochrane.org/ontologies/pico/comparatorGroup> <https://w3id.org/np/RA5e5XeXy_-aNK5giB7kBAEQslTLVydHeM4YYEzhmEE2w/comparatorGroup>;
+    <http://data.cochrane.org/ontologies/pico/interventionGroup> <https://w3id.org/np/RA5e5XeXy_-aNK5giB7kBAEQslTLVydHeM4YYEzhmEE2w/interventionGroup>;
+    <http://data.cochrane.org/ontologies/pico/outcomeGroup> <https://w3id.org/np/RA5e5XeXy_-aNK5giB7kBAEQslTLVydHeM4YYEzhmEE2w/outcomeGroup>;
+    <http://data.cochrane.org/ontologies/pico/population> <https://w3id.org/np/RA5e5XeXy_-aNK5giB7kBAEQslTLVydHeM4YYEzhmEE2w/population>;
+    dc:description "In a time-series of ERA5 integrated water-vapour transport (IVT) fields containing atmospheric rivers, does the CellProfiler object-tracking pipeline — IdentifyPrimaryObjects plus TrackObjects, built to follow dividing nuclei in fluorescence time-lapse and applied without modification through a Galaxy workflow, compared with the same algorithm run locally outside Galaxy, recover coherent atmospheric-river objects and their trajectories across consecutive 6-hourly time steps, including rivers that intensify, drift and split?";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Can a bioimaging object-tracking pipeline detect and track atmospheric rivers in ERA5 IVT via Galaxy?" .
+}
+`;
+
+const REAL_PCC_TRIG = `
+@prefix this: <https://w3id.org/sciencelive/np/RAEDNajh8Hz_fZbBRgOACKDxWrQYFfDYRks8-xxMEfKt4> .
+@prefix sub: <https://w3id.org/sciencelive/np/RAEDNajh8Hz_fZbBRgOACKDxWrQYFfDYRks8-xxMEfKt4/> .
+@prefix np: <http://www.nanopub.org/nschema#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix npx: <http://purl.org/nanopub/x/> .
+@prefix dc: <http://purl.org/dc/terms/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+sub:assertion {
+  <https://w3id.org/np/RAmR-xqMgOq3oTJmOVDQFL2p5usID6zqRapizHy0UJb04/concept> dc:description
+      "Artificial light at night (light pollution): the presence and spatial extent of artificial light within the protected area, and the proximity of lit human settlements to it." .
+  
+  <https://w3id.org/np/RAmR-xqMgOq3oTJmOVDQFL2p5usID6zqRapizHy0UJb04/context> dc:description
+      "VIIRS night-lights radiance (NASA Black Marble) over the eastern Po Valley, analysed with the astronomy Source Extractor tool (SExtractor / SEP) running in Galaxy (usegalaxy.eu), overlaid on the EU Natura 2000 protected-area network." .
+  
+  <https://w3id.org/np/RAmR-xqMgOq3oTJmOVDQFL2p5usID6zqRapizHy0UJb04/population> dc:description
+      "The Po Delta — a Ramsar and Natura 2000 wetland on the Italian Adriatic coast and a key site for migratory and breeding birds — together with the nocturnal biodiversity it supports." .
+  
+  sub:light-pollution-po-delta-nightlights a <https://w3id.org/sciencelive/o/terms/PccReviewQuestion>;
+    dc:description "How much artificial light at night intrudes on the Po Delta Natura 2000 protected area, when lit settlements are detected from VIIRS satellite night lights using an astronomy source-extraction tool run in Galaxy? This matters because artificial light at night is a documented stressor for the nocturnal birds, insects and bats that wetland refuges like the Po Delta support, and because it tests whether a tool from one discipline (astronomy) can be reused, unchanged, to answer an Earth-observation / biodiversity question.";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Artificial-light intrusion on the Po Delta protected area from night lights";
+    <https://w3id.org/sciencelive/o/terms/hasPccConcept> <https://w3id.org/np/RAmR-xqMgOq3oTJmOVDQFL2p5usID6zqRapizHy0UJb04/concept>;
+    <https://w3id.org/sciencelive/o/terms/hasPccContext> <https://w3id.org/np/RAmR-xqMgOq3oTJmOVDQFL2p5usID6zqRapizHy0UJb04/context>;
+    <https://w3id.org/sciencelive/o/terms/hasPccPopulation> <https://w3id.org/np/RAmR-xqMgOq3oTJmOVDQFL2p5usID6zqRapizHy0UJb04/population> .
+}
+`;
+
+describe("extractQuestionFields on real published nanopubs", () => {
+  it("reads a PICO root whose subject is a prefixed name", () => {
+    const q = extractQuestionFields(REAL_PICO_TRIG);
+
+    expect(q.framework).toBe("PICO");
+    expect(q.label).toMatch(/^Can a bioimaging object-tracking pipeline/);
+    // the FULL question, not the short label - different predicates, both needed
+    expect(q.question).toMatch(/^In a time-series of ERA5/);
+    expect(q.question).not.toBe(q.label);
+
+    expect(q.components.map((c) => c.label)).toEqual([
+      "Population",
+      "Intervention",
+      "Comparator",
+      "Outcome",
+    ]);
+    // each component resolved through its own node's description
+    for (const c of q.components) expect(c.text.length).toBeGreaterThan(40);
+    expect(q.components[0].text).toMatch(/integrated water-vapour transport/);
+    expect(q.components[1].text).toMatch(/CellProfiler object-tracking/);
+  });
+
+  it("reads a PCC root", () => {
+    const q = extractQuestionFields(REAL_PCC_TRIG);
+
+    expect(q.framework).toBe("PCC");
+    expect(q.label).toMatch(/^Artificial-light intrusion on the Po Delta/);
+    expect(q.question).toMatch(/^How much artificial light at night/);
+
+    expect(q.components.map((c) => c.label)).toEqual([
+      "Population",
+      "Concept",
+      "Context",
+    ]);
+    expect(q.components[0].text).toMatch(/Po Delta/);
+    expect(q.components[2].text).toMatch(/VIIRS night-lights/);
+  });
+
+  it("does not confuse a component's text with the root's question", () => {
+    // the trap: each component URI appears FIRST as an object of the root, so a
+    // subject-blind scan walks into the root's own description instead
+    const q = extractQuestionFields(REAL_PICO_TRIG);
+    for (const c of q.components) expect(c.text).not.toBe(q.question);
+  });
+});

--- a/api/src/np/trig.ts
+++ b/api/src/np/trig.ts
@@ -797,6 +797,48 @@ export function extractResearchSynthesisFields(
  * finds the object occurrence first and then walks into the ROOT's
  * description, silently returning the wrong text.
  */
+/**
+ * The `@prefix` declarations the document actually makes, as prefix -> namespace.
+ * Published nanopubs bind whatever prefixes their serialiser chose: the FORRT
+ * question nanopubs bind `dc:` to `http://purl.org/dc/terms/`, NOT `dct:`.
+ */
+function declaredPrefixes(trig: string): Map<string, string> {
+  const out = new Map<string, string>();
+  const re = /@prefix\s+([A-Za-z][\w.-]*)?:\s*<([^>]+)>\s*\./g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(trig)) !== null) out.set(m[1] ?? "", m[2]);
+  return out;
+}
+
+/**
+ * Every spelling `fullUri` can legally take in this document: the absolute
+ * form plus one prefixed form per declared prefix whose namespace it starts
+ * with. Guessing a conventional prefix instead is how an extractor passes its
+ * hand-written fixtures and returns nothing on real published data.
+ */
+function uriSpellings(trig: string, fullUri: string): string[] {
+  const out = [fullUri];
+  for (const [prefix, ns] of declaredPrefixes(trig)) {
+    if (fullUri.startsWith(ns) && fullUri.length > ns.length) {
+      out.push(`${prefix}:${fullUri.slice(ns.length)}`);
+    }
+  }
+  return out;
+}
+
+/** `extractPredicateValue`, tried against every spelling the document allows. */
+function extractPredicateValueAnySpelling(
+  block: string,
+  trig: string,
+  fullUri: string,
+): string | null {
+  for (const spelling of uriSpellings(trig, fullUri)) {
+    const v = extractPredicateValue(block, spelling);
+    if (v !== null) return v;
+  }
+  return null;
+}
+
 function isSubjectPosition(trig: string, at: number): boolean {
   let j = at - 1;
   while (j >= 0 && /\s/.test(trig[j])) j--;
@@ -851,12 +893,21 @@ function extractSubjectBlocks(
   trig: string,
 ): { subject: string; block: string }[] {
   const out: { subject: string; block: string }[] = [];
-  const re = /<([^>\s]+)>\s+/g;
+  const prefixes = declaredPrefixes(trig);
+  // Either an absolute <URI> or a prefixed name. isSubjectPosition does the
+  // real filtering, so matching loosely here is safe.
+  const re = /(?:<([^>\s]+)>|([A-Za-z][\w.-]*:[\w.\-%]+))\s+/g;
   let m: RegExpExecArray | null;
   while ((m = re.exec(trig)) !== null) {
     if (!isSubjectPosition(trig, m.index)) continue;
+    let subject = m[1] ?? m[2];
+    if (m[2]) {
+      const [prefix, ...rest] = m[2].split(":");
+      const ns = prefixes.get(prefix);
+      if (ns) subject = ns + rest.join(":");
+    }
     out.push({
-      subject: m[1],
+      subject,
       block: readSubjectSegment(trig, m.index + m[0].length),
     });
   }
@@ -988,8 +1039,8 @@ export function extractQuestionFields(trig: string): QuestionFields {
 
   return {
     framework,
-    label: extractLabelLike(rootBlock, RDFS_LABEL, "rdfs:label"),
-    question: extractLabelLike(rootBlock, DCT_DESCRIPTION, "dct:description"),
+    label: extractLabelLike(rootBlock, trig, RDFS_LABEL),
+    question: extractLabelLike(rootBlock, trig, DCT_DESCRIPTION),
     components,
   };
 }
@@ -1016,16 +1067,16 @@ function resolveComponentText(trig: string, value: string): string {
   if (!/^https?:\/\//.test(value)) return value.trim();
   const block = extractSubjectBlock(trig, value);
   if (block === null) return "";
-  return extractLabelLike(block, DCT_DESCRIPTION, "dct:description");
+  return extractLabelLike(block, trig, DCT_DESCRIPTION);
 }
 
 /** Full-URI form first, prefixed form second, `""` when neither is present. */
 function extractLabelLike(
   block: string,
+  trig: string,
   fullUri: string,
-  prefixedForm: string,
 ): string {
-  return (extractPredicateValueAny(block, fullUri, prefixedForm) ?? "").trim();
+  return (extractPredicateValueAnySpelling(block, trig, fullUri) ?? "").trim();
 }
 
 /** Suppress PROV_PREFIX import warning while keeping the constant available. */

--- a/api/src/np/trig.ts
+++ b/api/src/np/trig.ts
@@ -305,6 +305,16 @@ function extractObjectsFromSegment(segment: string): string[] {
  * `cito:isSupportedBy <a>, <b>, <c>;`.
  */
 function readObjectSegment(trig: string, start: number): string {
+  return readSegment(trig, start, ";.");
+}
+
+/**
+ * Walk forward from `start` until one of `terminators` appears OUTSIDE a
+ * quoted literal or a bracketed `<URI>`. Shared engine behind
+ * `readObjectSegment` (terminators `;.` — one predicate's object list) and
+ * `readSubjectSegment` (terminator `.` — a whole property list).
+ */
+function readSegment(trig: string, start: number, terminators: string): string {
   let i = start;
   let segment = "";
   while (i < trig.length) {
@@ -350,11 +360,19 @@ function readObjectSegment(trig: string, start: number): string {
       i = end + 1;
       continue;
     }
-    if (trig[i] === ";" || trig[i] === ".") return segment;
+    if (terminators.includes(trig[i])) return segment;
     segment += trig[i];
     i++;
   }
   return segment;
+}
+
+/**
+ * Walk forward from `start` to the end of a whole Turtle property list — the
+ * next un-quoted `.` — so `;`-separated predicates stay in one segment.
+ */
+function readSubjectSegment(trig: string, start: number): string {
+  return readSegment(trig, start, ".");
 }
 
 /**
@@ -757,6 +775,257 @@ export function extractResearchSynthesisFields(
     topicQids: wikidataQs,
     endDate: extractPredicateValue(trig, `${SCHEMA_PREFIX}endDate`) ?? "",
   };
+}
+
+// =============================================================================
+// Subject-aware lookup
+// =============================================================================
+
+/**
+ * Is the `<URI>` occurrence starting at `at` in SUBJECT position?
+ *
+ * Turtle puts a URI in subject position only at the very start of the graph
+ * body or straight after a statement boundary. We skip backwards over
+ * whitespace and require the previous significant character to be `{`, `}`
+ * or `.`. Anything else — `;` (next predicate of the SAME subject), `,`
+ * (next object), a bare `a`, or the `>` that closes a predicate URI — means
+ * the occurrence is a predicate or an object, not a subject.
+ *
+ * This distinction is the whole point of the helper: a PICO/PCC component
+ * URI appears BOTH as the object of the root's component predicate AND as
+ * the subject of its own `dct:description` statement. A subject-blind scan
+ * finds the object occurrence first and then walks into the ROOT's
+ * description, silently returning the wrong text.
+ */
+function isSubjectPosition(trig: string, at: number): boolean {
+  let j = at - 1;
+  while (j >= 0 && /\s/.test(trig[j])) j--;
+  if (j < 0) return true;
+  return trig[j] === "{" || trig[j] === "}" || trig[j] === ".";
+}
+
+/**
+ * Return the Turtle property list attached to `subjectUri` where that URI
+ * appears as a SUBJECT — i.e. the text between the subject and the statement's
+ * closing `.`. Returns null when the URI never appears in subject position
+ * (it may still appear as an object elsewhere).
+ *
+ * Only absolute `<URI>` subjects are matched; prefixed names (`sub:assertion`)
+ * are out of scope, which is fine for FORRT assertion graphs where the chain
+ * subjects are always written out in full.
+ */
+export function extractSubjectBlock(
+  trig: string,
+  subjectUri: string,
+): string | null {
+  const escaped = subjectUri.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const re = new RegExp(`<${escaped}>\\s+`, "g");
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(trig)) !== null) {
+    if (!isSubjectPosition(trig, m.index)) continue;
+    return readSubjectSegment(trig, m.index + m[0].length);
+  }
+  return null;
+}
+
+/**
+ * `extractPredicateValue` scoped to one subject's property list. Returns null
+ * when the subject has no such statement.
+ */
+export function extractPredicateValueForSubject(
+  trig: string,
+  subjectUri: string,
+  predicate: string,
+): string | null {
+  const block = extractSubjectBlock(trig, subjectUri);
+  if (block === null) return null;
+  return extractPredicateValue(block, predicate);
+}
+
+/**
+ * Every URI that appears in SUBJECT position, paired with its property list.
+ * Document order; duplicates (a subject written twice) are kept so callers
+ * can pick the block that actually carries the predicate they want.
+ */
+function extractSubjectBlocks(
+  trig: string,
+): { subject: string; block: string }[] {
+  const out: { subject: string; block: string }[] = [];
+  const re = /<([^>\s]+)>\s+/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(trig)) !== null) {
+    if (!isSubjectPosition(trig, m.index)) continue;
+    out.push({
+      subject: m[1],
+      block: readSubjectSegment(trig, m.index + m[0].length),
+    });
+  }
+  return out;
+}
+
+// =============================================================================
+// PICO / PCC research-question roots
+// =============================================================================
+
+const PICO_PREFIX = "http://data.cochrane.org/ontologies/pico/";
+const RDFS_LABEL = "http://www.w3.org/2000/01/rdf-schema#label";
+const DCT_DESCRIPTION = `${DCT_PREFIX}description`;
+
+/**
+ * One component of a structured research question, in a framework-neutral
+ * shape so PICO's four and PCC's three render through the same code path.
+ * `key` is stable for clients; `label` is the display heading.
+ */
+export type QuestionComponent = {
+  key: string;
+  label: string;
+  text: string;
+};
+
+export type QuestionFields = {
+  framework: "PICO" | "PCC" | "";
+  /** The root's `rdfs:label` — a short headline for the question. */
+  label: string;
+  /** The root's `dct:description` — the FULL research-question text. */
+  question: string;
+  components: QuestionComponent[];
+};
+
+type ComponentSpec = { key: string; label: string; predicate: string };
+
+// Fixed, meaningful order — this is the order the acronyms are read in.
+const PICO_COMPONENTS: ComponentSpec[] = [
+  {
+    key: "population",
+    label: "Population",
+    predicate: `${PICO_PREFIX}population`,
+  },
+  {
+    key: "intervention",
+    label: "Intervention",
+    predicate: `${PICO_PREFIX}interventionGroup`,
+  },
+  {
+    key: "comparator",
+    label: "Comparator",
+    predicate: `${PICO_PREFIX}comparatorGroup`,
+  },
+  { key: "outcome", label: "Outcome", predicate: `${PICO_PREFIX}outcomeGroup` },
+];
+
+const PCC_COMPONENTS: ComponentSpec[] = [
+  {
+    key: "population",
+    label: "Population",
+    predicate: `${FORRT_TERMS}hasPccPopulation`,
+  },
+  {
+    key: "concept",
+    label: "Concept",
+    predicate: `${FORRT_TERMS}hasPccConcept`,
+  },
+  {
+    key: "context",
+    label: "Context",
+    predicate: `${FORRT_TERMS}hasPccContext`,
+  },
+];
+
+/**
+ * Extract the root research question of a FORRT chain that starts with a
+ * PICO or PCC question rather than a Paper Quotation.
+ *
+ * Shape of the assertion (PICO; PCC is the same with the FORRT `hasPcc*`
+ * predicates and three components):
+ *
+ *   <root> a pico:PICO;
+ *     rdfs:label "Short headline";
+ *     dct:description "The full research question text?";
+ *     pico:population <root/population>;
+ *     pico:interventionGroup <root/intervention> .
+ *   <root/population> dct:description "Adults over 65" .
+ *
+ * Note the INDIRECTION: the component predicates point at component nodes,
+ * and the human-readable text hangs off each node's own `dct:description`.
+ * Reading the predicate alone yields a URI, so every component is resolved
+ * through the subject-aware lookup above.
+ *
+ * Returns `framework: ""` with empty fields when the TriG is not a research
+ * question.
+ */
+export function extractQuestionFields(trig: string): QuestionFields {
+  const empty: QuestionFields = {
+    framework: "",
+    label: "",
+    question: "",
+    components: [],
+  };
+
+  const framework = detectQuestionFramework(trig);
+  if (framework === "") return empty;
+
+  const specs = framework === "PICO" ? PICO_COMPONENTS : PCC_COMPONENTS;
+
+  // The root is the subject carrying the component predicates. Scanning
+  // subject blocks (rather than assuming the first statement) keeps this
+  // correct when the assertion graph lists component nodes first.
+  const rootBlock =
+    extractSubjectBlocks(trig).find(({ block }) =>
+      specs.some((s) => extractPredicateValue(block, s.predicate) !== null),
+    )?.block ?? "";
+  if (rootBlock === "") return { ...empty, framework };
+
+  const components: QuestionComponent[] = [];
+  for (const spec of specs) {
+    const value = extractPredicateValue(rootBlock, spec.predicate);
+    if (value === null) continue;
+    components.push({
+      key: spec.key,
+      label: spec.label,
+      text: resolveComponentText(trig, value),
+    });
+  }
+
+  return {
+    framework,
+    label: extractLabelLike(rootBlock, RDFS_LABEL, "rdfs:label"),
+    question: extractLabelLike(rootBlock, DCT_DESCRIPTION, "dct:description"),
+    components,
+  };
+}
+
+/**
+ * PICO vs PCC. Prefer the rdf:type marker, fall back to "any component
+ * predicate of that framework is present" so a minor vocabulary drift in the
+ * type URI doesn't lose the whole question.
+ */
+function detectQuestionFramework(trig: string): "PICO" | "PCC" | "" {
+  if (trig.includes(`${PICO_PREFIX}PICO`)) return "PICO";
+  if (trig.includes(`${FORRT_TERMS}PccReviewQuestion`)) return "PCC";
+  if (PICO_COMPONENTS.some((s) => trig.includes(s.predicate))) return "PICO";
+  if (PCC_COMPONENTS.some((s) => trig.includes(s.predicate))) return "PCC";
+  return "";
+}
+
+/**
+ * A component predicate's object is normally a component-node URI whose own
+ * `dct:description` carries the text. Some publishers inline the text as a
+ * literal instead, so accept that too.
+ */
+function resolveComponentText(trig: string, value: string): string {
+  if (!/^https?:\/\//.test(value)) return value.trim();
+  const block = extractSubjectBlock(trig, value);
+  if (block === null) return "";
+  return extractLabelLike(block, DCT_DESCRIPTION, "dct:description");
+}
+
+/** Full-URI form first, prefixed form second, `""` when neither is present. */
+function extractLabelLike(
+  block: string,
+  fullUri: string,
+  prefixedForm: string,
+): string {
+  return (extractPredicateValueAny(block, fullUri, prefixedForm) ?? "").trim();
 }
 
 /** Suppress PROV_PREFIX import warning while keeping the constant available. */


### PR DESCRIPTION
## Problem

A FORRT chain's root (step 1) can be a Paper Quotation, a **PICO** research question, or a **PCC** research question. Only Quotation was recognised. PICO and PCC roots fell through `classifyStepKind` to `stepKind: "other"` and were therefore **missing from `chains[].steps`** — the node was returned in `nodes[]`, just never typed or sequenced as a step.

Verified live against `api-dev`:

| chain | root | `chains[].steps` before |
|---|---|---|
| CellProfiler / atmospheric rivers | PICO | starts at `AIDA` |
| Source Extractor / Po Delta | PCC | starts at `AIDA` |
| few-shot EuroSAT (4 chains) | Quote | correct — starts at `Quote` |

This is the residue left by #97, which fixed the *traversal* (the walk now crosses `Claim → AIDA → root`) but not the *classification*.

## Fix

- `"question"` `StepKind` + `"Question"` `ChainStep`, carrying `framework` (`PICO`/`PCC`), the short label, the full question, and the ordered components (PICO: Population/Intervention/Comparator/Outcome; PCC: Population/Concept/Context).
- `extractQuestionFields()` in `trig.ts`, plus subject-aware extraction helpers.
- The Question step is pushed **first**, in the position Quote occupies.

### The component values are indirect

`pico:population` and friends do not carry text — their object is a component-node URI, and *that* node carries the text as its own `dct:description`. The root separately carries `rdfs:label` (short title) **and** `dct:description` (the full question); they are different predicates and both matter.

This needs subject-aware lookup, because each component URI appears **first as an object** of the root. A subject-blind "first `dct:description` after this URI" scan walks into the root's description and silently returns the wrong text. `isSubjectPosition()` handles it, and a regression test asserts the naive result is *not* returned.

## Real published nanopubs are in the tests, deliberately

The first implementation passed **238 hand-written tests and extracted nothing from real data** — correct `framework`, then empty label, empty question, zero components. Two spelling assumptions caused it:

| assumed | actually published |
|---|---|
| subjects are absolute `<URI>` | root subject is a prefixed name, `sub:<slug>` |
| `dct:description` | `dc:description`, with `dc:` bound to `purl.org/dc/terms/` |

Fixed by reading the document's own `@prefix` declarations and trying every spelling a URI can legally take in it, rather than guessing a conventional one.

Three tests now run over the real CellProfiler PICO root and Po Delta PCC root, copied verbatim from the resolver and inlined as template literals — the same way every other TriG in `trig.test.ts` is supplied. There is a comment asking not to normalise them: the `sub:` subject and `dc:` prefix look like noise but are exactly the properties under test.

Worth flagging beyond this PR: **every other extractor in `trig.ts` is validated only against TriG hand-written to match it.** `extractStudyFields`, `extractQuoteFields` and `extractResearchSynthesisFields` have three test references each. If any of them makes the same spelling assumption, the current suite cannot tell.

## Known limitation (deliberate)

FORRT has no AIDA→root predicate, so `findQuestionForAida` mirrors the existing `findQuoteForAida`: it matches only when there is **exactly one** question node in the constellation. With several question-rooted chains in one constellation it emits **no** Question step rather than risk attaching the wrong research question to a chain — a wrong attribution silently misrepresents someone's work, a missing step is visibly incomplete. Documented in a `KNOWN LIMITATION` block. A general fix needs a root predicate in the vocabulary, or Study→question linkage.

In practice a constellation has one question, so this covers the real cases.

## Not fixed here

- **`apexCito` is `null`** on all three chains checked, despite `cito` nodes present and `citoRelations` populated. Separate defect, untouched.
- **Superseded nanopubs are not filtered** by the endpoint. `replication-radar`'s `network.py` already solves this with an `npx:retracts`/`invalidates`/`supersedes` guard, with the neat condition that the superseding nanopub shares the same creator — worth copying rather than reinventing.
- `isTemplateDefinitionLabel()` returns true for anything starting with `"defining a"`, which both question templates do (`"Defining a PICO-based research question"`). That makes a question node contribute no neighbours during the BFS. It does not affect this fix — the node is still discovered from downstream — but it looks like an accident waiting to matter. Left alone as out of scope.

## Verification

- `npx vitest run api/src/np/` → **241 passing** (was 221).
- `npx tsc --noEmit` clean; `npx eslint src/np/` clean.
- Extraction confirmed against the two real nanopubs: both frameworks, both labels, both full questions, 4/4 and 3/3 components resolved through their component nodes.

## Independence

`api/` only. **No file overlap with #101 (create wizard) or #102 (view components)**, and the frontend imports no constellation types — the three can merge in any order.

Note there is no in-repo consumer of `/np/constellation` yet, so there is nothing to see in the UI; the consumers are external (the story-page generator, and anything walking chains). `replication-radar` is unaffected — it queries SPARQL directly and stops at the Claim.

