### PR TITLE
Fix E2E browse test asserting pagination that its own skip path cannot satisfy

### DIFF
--- a/e2e/browse_filter_pagination/browse_filter_pagination.test.ts
+++ b/e2e/browse_filter_pagination/browse_filter_pagination.test.ts
@@ -78,18 +78,31 @@ describe("Browse, filter and pagination", () => {
     );
 
     // CP6 - Click Next to go to Page 2
+    //
+    // Pagination can only be exercised when the filtered result set spans more
+    // than one page, which depends on how many nanopublications the browse
+    // query returns - live data this test does not control. When the set fits
+    // on one page the platform renders no pager at all, so there is no Next
+    // button AND no "Page 1"/"Page 2" text to find.
+    //
+    // Assert inside the branch. Asserting outside it made the documented
+    // "skipping" path fail unconditionally, so the whole suite turned red the
+    // day the Core-filtered result set shrank to a single page.
     artifacts.log("CP6: Clicking 'Next' button to go to Page 2");
     const nextBtn = page.getByRole("button", { name: "Next" });
-    let page2Displayed = false;
-    if ((await nextBtn.count()) > 0 && !(await nextBtn.isDisabled())) {
+    const canPaginate =
+      (await nextBtn.count()) > 0 && !(await nextBtn.isDisabled());
+    if (canPaginate) {
       await nextBtn.click();
       await page.waitForTimeout(3000);
       await artifacts.screenshot(page, "07_page_2.png");
-      page2Displayed = (await page.locator("text=Page 2").count()) > 0;
+      const page2Displayed = (await page.locator("text=Page 2").count()) > 0;
+      expect.soft(page2Displayed, "CP6 - Page 2 displayed").toBe(true);
     } else {
-      artifacts.log("CP6: Next button not available or disabled - skipping");
+      artifacts.log(
+        "CP6: no enabled Next button - the filtered result set fits on one page, so pagination is not exercisable in this run",
+      );
     }
-    expect.soft(page2Displayed, "CP6 - Page 2 displayed").toBe(true);
 
     // CP7 - Change sort back to Newest First and verify it returns to Page 1
     artifacts.log("CP7: Changing sort back to 'Newest First'");
@@ -100,8 +113,13 @@ describe("Browse, filter and pagination", () => {
     await artifacts.screenshot(page, "08_newest_first.png");
     const newestSortValue = await page.getByRole("combobox").innerText();
     const newestSorted = newestSortValue.includes("Newest");
-    const backToPage1 = (await page.locator("text=Page 1").count()) > 0;
-    expect.soft(newestSorted && backToPage1, "CP7 - Newest First sort and Page 1 restored").toBe(true);
+    // The sort itself is always checkable; "back to Page 1" only means
+    // something if we actually left page 1.
+    expect.soft(newestSorted, "CP7 - Sorted by Newest First").toBe(true);
+    if (canPaginate) {
+      const backToPage1 = (await page.locator("text=Page 1").count()) > 0;
+      expect.soft(backToPage1, "CP7 - Page 1 restored after re-sorting").toBe(true);
+    }
 
     // CP8 - Clear filters
     artifacts.log("CP8: Clicking 'Clear filters' button");


### PR DESCRIPTION
## Problem

`main` is red, and no code change caused it. The test's own log from the failing run on `main` says exactly what happened:

```
CP6: Clicking 'Next' button to go to Page 2
CP6: Next button not available or disabled - skipping
```

`07_page_2.png` is absent from the uploaded screenshots, confirming the click never happened.

CP6 handles "no Next button" by logging that it is **skipping**, then asserts `page2Displayed` **outside** the `if` — so the documented skip path could only ever fail:

```ts
if (nextBtn exists && enabled) { ...; page2Displayed = ... }
else { artifacts.log("... skipping"); }
expect.soft(page2Displayed, "CP6 - Page 2 displayed").toBe(true);   // ← always fails on the skip path
```

It passed until now only because the `Core`-filtered, `Most Referenced`-sorted result set happened to span two pages. It no longer does. When a result set fits on one page the platform renders **no pager at all**, so neither `text=Page 2` nor `text=Page 1` exists — which is why CP7 ("Page 1 restored") failed in the same run.

## Fix

- Assert **inside** the branch that can actually observe page 2.
- Split CP7: the sort change is always checkable, but "Page 1 restored" only means something if we actually left page 1.
- The skip path now logs why pagination was not exercisable.

## Why this is not a regression from any open PR

The same failure appeared on `fix/constellation-pico-pcc-root` (#103), which is `api/`-only. Between that branch's green run and its red run, the diff was:

```
api/src/np/__fixtures__/question-pcc.trig    (deleted)
api/src/np/__fixtures__/question-pico.trig   (deleted)
api/src/np/question-realdata.test.ts         (deleted)
api/src/np/trig.test.ts                      (moved into)
```

`git diff --stat` on `trig.ts` and `constellation.ts` between those two commits is **empty** — identical production code, green then red. `main` then failed the same way carrying none of #103. The variable was the data, not the code.

## Known remaining weakness

The test still depends on live nanopublication counts it does not control, so it can flip again as the network grows or shrinks — it just fails honestly now instead of asserting something it never observed. Making it deterministic needs a seeded dataset for the browse query; worth doing, but a bigger change than unblocking `main`.

## Verification

`npx tsc --noEmit -p e2e/tsconfig.json` → clean. The e2e suite itself needs the full local stack (Postgres + API + frontend), so CI is the real check here — I could not run it locally.
