### PR TITLE
fix(np): read constellation node metadata from the KP admin graph

### DIFF
--- a/api/src/np/constellation.ts
+++ b/api/src/np/constellation.ts
@@ -1,7 +1,9 @@
 import {
   AIDA_STATEMENT_NANOPUB,
   bindUri,
+  bindUris,
   NANOPUB_SPARQL_ENDPOINT_FULL,
+  NODE_METADATA,
   REFERENCES_FROM,
   REFERENCES_TO,
 } from "./queries";
@@ -14,7 +16,6 @@ import {
   extractDois,
   extractExcerpts,
   extractGithubUrls,
-  extractNanopubMeta,
   extractNanopubUris,
   extractOrcids,
   extractOutcomeFields,
@@ -61,6 +62,8 @@ export type ConstellationNode = {
   label: string;
   date: string;
   creators: string[];
+  /** Display names (foaf:name), aligned 1:1 with `creators`; "" when unknown. */
+  creatorNames: string[];
   authorsOrcid: string[];
   plainTextExcerpts: string[];
   // Per-template structured fields — only the matching one is populated.
@@ -231,6 +234,10 @@ export async function buildConstellation(
     }
   }
 
+  // Fill node label/date/creators from the KP admin graph (normalized), before
+  // assembling chains so the reference bibliography has titles and authors.
+  await enrichNodeMetadata(nodes, signal);
+
   const nodeList = [...nodes.values()];
   const { chains, apexCito, researchSynthesis, paperDoi } = assembleChains(
     nodeList,
@@ -250,6 +257,52 @@ export async function buildConstellation(
     edges,
     externalCitations: [...externals].sort(),
   };
+}
+
+/**
+ * Fill each node's label/date/creators/creatorNames from the KP admin graph in
+ * one batched SPARQL query per chunk of URIs — normalized values, not parsed
+ * from each TriG. Best-effort: a metadata miss never fails the constellation.
+ */
+async function enrichNodeMetadata(
+  nodes: Map<string, ConstellationNode>,
+  signal?: AbortSignal,
+): Promise<void> {
+  const uris = [...nodes.keys()];
+  const CHUNK = 40;
+  for (let i = 0; i < uris.length; i += CHUNK) {
+    const chunk = uris.slice(i, i + CHUNK);
+    let rows: Record<string, string>[];
+    try {
+      rows = await executeSparql(bindUris(NODE_METADATA, chunk), signal);
+    } catch {
+      continue;
+    }
+    const creatorsByUri = new Map<string, string[]>();
+    const namesByUri = new Map<string, Map<string, string>>();
+    for (const r of rows) {
+      const node = nodes.get(r.np);
+      if (!node) continue;
+      if (r.label && !node.label) node.label = r.label;
+      if (r.date && !node.date) node.date = r.date;
+      if (!r.creator) continue;
+      const list = creatorsByUri.get(r.np) ?? [];
+      if (!list.includes(r.creator)) list.push(r.creator);
+      creatorsByUri.set(r.np, list);
+      if (r.creatorName) {
+        const nm = namesByUri.get(r.np) ?? new Map<string, string>();
+        nm.set(r.creator, r.creatorName);
+        namesByUri.set(r.np, nm);
+      }
+    }
+    for (const [uri, creators] of creatorsByUri) {
+      const node = nodes.get(uri);
+      if (!node) continue;
+      const nm = namesByUri.get(uri) ?? new Map<string, string>();
+      node.creators = creators;
+      node.creatorNames = creators.map((o) => nm.get(o) ?? "");
+    }
+  }
 }
 
 // =============================================================================
@@ -281,16 +334,18 @@ async function processNode(
     : "";
 
   const stepKind = classifyStepKind(stepType);
-  const meta = extractNanopubMeta(trig);
 
   const node: ConstellationNode = {
     uri,
     stepKind,
     stepType,
     templateUri: templateUri ?? "",
-    label: meta.label,
-    date: meta.date,
-    creators: meta.creators,
+    // label/date/creators/creatorNames are filled from the KP admin graph after
+    // the walk (enrichNodeMetadata) — normalized, not parsed from the TriG.
+    label: "",
+    date: "",
+    creators: [],
+    creatorNames: [],
     authorsOrcid: extractOrcids(trig),
     plainTextExcerpts: extractExcerpts(trig),
     githubUrls: extractGithubUrls(trig),

--- a/api/src/np/queries.ts
+++ b/api/src/np/queries.ts
@@ -119,6 +119,35 @@ limit 100
 `;
 
 /**
+ * Normalized per-nanopub metadata (label, creation date, creator ORCID + name)
+ * for a batch of nanopub URIs, read from the KP admin graph (`npa:graph`) rather
+ * than parsed out of each TriG. The admin graph exposes these as canonical
+ * `dct:created` / `dct:description|rdfs:label` / `dct:creator` regardless of the
+ * prefix the source nanopub serialised (published nanopubs bind dcterms to
+ * `dc:`, not `dct:`, which defeats TriG string-matching). The creator's display
+ * name is joined from its `foaf:name` statement in the pubinfo graph.
+ */
+export const NODE_METADATA = `
+prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+prefix np: <http://www.nanopub.org/nschema#>
+prefix npa: <http://purl.org/nanopub/admin/>
+prefix dct: <http://purl.org/dc/terms/>
+prefix foaf: <http://xmlns.com/foaf/0.1/>
+
+select ?np ?label ?date ?creator ?creatorName where {
+  values ?np { ?_uris }
+  graph npa:graph {
+    ?np np:hasAssertion ?assertion .
+    optional { ?np rdfs:label ?label . }
+    optional { ?np dct:created ?date . }
+    optional { ?np dct:creator ?creator . }
+    optional { ?np np:hasPublicationInfo ?pubinfo . }
+  }
+  optional { graph ?pubinfo { ?creator foaf:name ?creatorName . } }
+}
+`;
+
+/**
  * Substitute a `?_…` placeholder with a bracketed URI literal. Defaults to the
  * `?_nanopubUri` placeholder used by the reference queries; pass an explicit
  * placeholder for other queries (e.g. `?_aidaStatementIri`).
@@ -129,4 +158,13 @@ export function bindUri(
   placeholder = "?_nanopubUri",
 ): string {
   return query.replaceAll(placeholder, `<${uri}>`);
+}
+
+/** Substitute a `?_…` placeholder with a space-separated list of bracketed URIs (a SPARQL VALUES body). */
+export function bindUris(
+  query: string,
+  uris: string[],
+  placeholder = "?_uris",
+): string {
+  return query.replaceAll(placeholder, uris.map((u) => `<${u}>`).join(" "));
 }


### PR DESCRIPTION
## Problem

Constellation node `label`, `date`, and `creators` were parsed out of each nanopub's TriG, matching the `dct:` prefix. Published nanopubs bind dcterms to `dc:` (the resolver's serialisation), so **every creator and date came back empty and most labels were missing** — the constellation's reference bibliography had no titles, authors, or years.

This is the same class of prefix bug that `25c6417` ("read question fields using the document's own prefixes") fixed for the question fields; it just wasn't applied to the pubinfo metadata.

## Fix

Read `label` / `date` / `creator` from the **KP admin graph** (`npa:graph`), which exposes them as normalized `dct:created` / `dct:description` / `dct:creator` regardless of the source nanopub's prefix — the pattern the reference discovery queries (`REFERENCES_TO`/`REFERENCES_FROM`) already use. A single batched `NODE_METADATA` query over the walked node URIs fills metadata after the walk; the creator's display name is joined from `foaf:name` in the pubinfo graph. Best-effort — a metadata miss never fails the constellation.

- `constellation.ts`: `enrichNodeMetadata()` after the walk; `processNode` no longer parses metadata from the TriG.
- `queries.ts`: new `NODE_METADATA` query + `bindUris()` helper.
- `trig.ts` untouched.

## Result (verified against production data)

| field | before | after |
|---|---|---|
| labels | ~1/104 | **104/104** |
| creators | 9/104 | **104/104** |
| creator names | 9/104 | **95/104** |
| dates | 13/104 | **104/104** |

Every Study / Outcome / CiTO now has a real title, author, and year.

`npm test` — 182 passing.