### PR TITLE
perf(np): cache the /np/constellation walk at the Cloudflare edge

### DIFF
--- a/api/src/np/index.ts
+++ b/api/src/np/index.ts
@@ -16,6 +16,14 @@ const app = new Hono<{
 // Adjust as needed. Deployment may have its own limits regardless.
 const ENDPOINT_TIMEOUT = 60_000; // 60s
 
+// A constellation aggregates published (immutable) nanopublications and only
+// changes when a *new* nanopub extends it, which is rare. Caching the response
+// at the Cloudflare edge turns repeat views — the common case for a shared story
+// page — from a ~1-minute walk into an instant hit. Kept modest so a newly
+// published replication still surfaces within the hour; pre-warm featured
+// stories to keep them permanently hot.
+const CACHE_TTL_SECONDS = 3600; // 1 hour
+
 /**
  * GET /np/constellation?uri=<nanopub-uri>&depth=<n>&maxNodes=<n>
  *
@@ -58,6 +66,21 @@ app.get("/constellation", async (c) => {
   const depthLimit = clampInt(c.req.query("depth"), 0, 10, 5);
   const maxNodes = clampInt(c.req.query("maxNodes"), 1, 200, 80);
 
+  // Serve from the Cloudflare edge cache if we've already walked this exact
+  // constellation. The key is normalised to the canonical (uri, depth, maxNodes)
+  // so it's independent of query-param order or extras.
+  const cacheKey = new Request(
+    `https://np-constellation.cache/?uri=${encodeURIComponent(entry)}&depth=${depthLimit}&maxNodes=${maxNodes}`,
+  );
+  // `caches` is a Workers-runtime global; absent under plain unit tests / other
+  // hosts, so guard it and fall through to a live walk when there's no cache.
+  const cache =
+    typeof caches !== "undefined"
+      ? await caches.open("np-constellation")
+      : null;
+  const cached = cache ? await cache.match(cacheKey) : null;
+  if (cached) return cached;
+
   // Request-level timeout with AbortSignal
   const ac = new AbortController();
   const timer = setTimeout(() => ac.abort(), ENDPOINT_TIMEOUT);
@@ -80,13 +103,19 @@ app.get("/constellation", async (c) => {
       );
     }
 
-    // TODO: if we want to utilize short-lived caching, we can enable this
-    // to reduce server load.  Other options may exist depending on deployment,
-    // e.g. within Cloudflare.
-    // Add cache headers for immutable nanopub data
-    // c.header("Cache-Control", "public, max-age=300"); // 5 minutes
-
-    return c.json(constellation);
+    // Cache the successful walk at the edge (see CACHE_TTL_SECONDS). Only 200s
+    // are cached — 404s/timeouts fall through so a transient failure isn't stuck.
+    const response = c.json(constellation);
+    response.headers.set(
+      "Cache-Control",
+      `public, max-age=${CACHE_TTL_SECONDS}`,
+    );
+    if (cache) {
+      const put = cache.put(cacheKey, response.clone());
+      if (c.executionCtx) c.executionCtx.waitUntil(put);
+      else await put;
+    }
+    return response;
   } catch (err) {
     // Differentiate upstream failures (502) from programmer errors (500)
     if (err instanceof UpstreamError) {


### PR DESCRIPTION
## Problem

The `/np/constellation` walk takes **~60s** — ≈100 nodes, each a TriG fetch plus a few SPARQL queries over KP's endpoint. Since the story page (`/np/story`) is driven by this walk, **every visitor to a shared story waits a minute**. (Measured identical locally and on dev — it's the walk, not the environment.)

## Fix

A constellation aggregates **published, immutable** nanopublications and only changes when a *new* nanopub extends it — rare. So cache the successful response at the **Cloudflare edge** (Cache API), keyed by the canonical `(uri, depth, maxNodes)`:

- Cache **hit** → returned instantly.
- Cache **miss** → walk once, then store with `Cache-Control: public, max-age=3600`.
- Only **200s** are cached — 404s / timeouts fall through so a transient failure isn't stuck.
- The `caches` global is **guarded** (`typeof caches !== "undefined"`) so unit tests and non-Workers hosts still run a live walk.

## Result (verified locally)

| request | time |
|---|---|
| 1st (miss — walks) | **61.9s** |
| 2nd (**cache hit**) | **0.024s** |

Full payload intact on the hit (102 nodes, 2 chains, 98 author names).

TTL is 1h so a newly published replication still surfaces quickly. **Featured stories (e.g. the ones linked from sciencelive4all.org) can be pre-warmed** — a scheduled fetch keeps them permanently hot so the public never waits. (Pre-warming is a small follow-up, tied to the homepage "Featured stories" list.)

`npm test` — all np tests pass.